### PR TITLE
Discord連携やメール認証を確認してからメンバー申請を承認する

### DIFF
--- a/UniQUE-API/src/docs/docs.go
+++ b/UniQUE-API/src/docs/docs.go
@@ -2186,6 +2186,9 @@ const docTemplate = `{
                 "email": {
                     "type": "string"
                 },
+                "force": {
+                    "type": "boolean"
+                },
                 "joined_at": {
                     "type": "string"
                 },

--- a/UniQUE-API/src/docs/swagger.json
+++ b/UniQUE-API/src/docs/swagger.json
@@ -2176,6 +2176,9 @@
                 "email": {
                     "type": "string"
                 },
+                "force": {
+                    "type": "boolean"
+                },
                 "joined_at": {
                     "type": "string"
                 },

--- a/UniQUE-API/src/docs/swagger.yaml
+++ b/UniQUE-API/src/docs/swagger.yaml
@@ -446,6 +446,8 @@ definitions:
         type: string
       email:
         type: string
+      force:
+        type: boolean
       joined_at:
         type: string
       sakura_email_password:

--- a/UniQUE-API/src/internal/routes/dto.go
+++ b/UniQUE-API/src/internal/routes/dto.go
@@ -49,6 +49,7 @@ type UserApproveDTO struct {
 	AffiliationPeriod   string `json:"affiliation_period"`
 	JoinedAt            string `json:"joined_at"`
 	SakuraEmailPassword string `json:"sakura_email_password"`
+	Force               *bool  `json:"force,omitempty"`
 }
 
 type UserPasswordChangeDTO struct {

--- a/UniQUE-API/src/internal/routes/users.go
+++ b/UniQUE-API/src/internal/routes/users.go
@@ -1691,8 +1691,31 @@ func approveUserRegist(c *gin.Context) {
 		return
 	}
 
-	updates := map[string]interface{}{"status": "active"}
-	updateProfiles := map[string]interface{}{}
+	if dto.Force == nil || !*dto.Force {
+		// EmailVerifiedを確認
+		existedUser, err := q.User.Where(q.User.ID.Eq(user_id)).First()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if !existedUser.EmailVerified {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "external_email_not_verified"})
+			return
+		}
+		// Discord連携を確認
+		count, err := q.ExternalIdentity.Where(q.ExternalIdentity.UserID.Eq(existedUser.ID), q.ExternalIdentity.Provider.Eq("discord")).Count()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if count == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"erroor": "discord_is_not_linked"})
+			return
+		}
+	}
+
+	updates := map[string]any{"status": "active"}
+	updateProfiles := map[string]any{}
 
 	updates["email"] = dto.Email
 	updates["affiliation_period"] = dto.AffiliationPeriod

--- a/UniQUE-API/src/internal/routes/users.go
+++ b/UniQUE-API/src/internal/routes/users.go
@@ -1691,13 +1691,18 @@ func approveUserRegist(c *gin.Context) {
 		return
 	}
 
-	if dto.Force == nil || !*dto.Force {
-		// EmailVerifiedを確認
-		existedUser, err := q.User.Where(q.User.ID.Eq(user_id)).First()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	existedUser, err := q.User.Where(q.User.ID.Eq(user_id)).First()
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "notfound"})
 			return
 		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if dto.Force == nil || !*dto.Force {
+		// EmailVerifiedを確認
 		if !existedUser.EmailVerified {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "external_email_not_verified"})
 			return

--- a/UniQUE-API/src/internal/routes/users.go
+++ b/UniQUE-API/src/internal/routes/users.go
@@ -1714,7 +1714,7 @@ func approveUserRegist(c *gin.Context) {
 			return
 		}
 		if count == 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"erroor": "discord_is_not_linked"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "discord_is_not_linked"})
 			return
 		}
 	}

--- a/UniQUE-Front/src/classes/User.ts
+++ b/UniQUE-Front/src/classes/User.ts
@@ -464,11 +464,13 @@ export class User {
     email,
     sakuraEmailPassword,
     joinedAt,
+    force,
   }: {
     affiliationPeriod: string;
     email: string;
     sakuraEmailPassword: string;
     joinedAt?: string;
+    force?: boolean | null;
   }): Promise<void> {
     const response = await apiPost(`/users/${this.id}/approve`, {
       affiliationPeriod: affiliationPeriod,
@@ -479,6 +481,7 @@ export class User {
         : new Date().toLocaleDateString("sv-SE", {
             timeZone: "Asia/Tokyo",
           }), // 日付のみ
+      force: force ? force : null,
     });
     if (!response.ok) {
       switch (response.status) {

--- a/UniQUE-Front/src/classes/User.ts
+++ b/UniQUE-Front/src/classes/User.ts
@@ -481,7 +481,7 @@ export class User {
         : new Date().toLocaleDateString("sv-SE", {
             timeZone: "Asia/Tokyo",
           }), // 日付のみ
-      force: force ? force : null,
+      force: force == null ? undefined : force,
     });
     if (!response.ok) {
       switch (response.status) {

--- a/UniQUE-Front/src/classes/types/User.ts
+++ b/UniQUE-Front/src/classes/types/User.ts
@@ -21,5 +21,4 @@ export interface UserData {
   createdAt: string | Date;
   updatedAt: string | Date;
   deletedAt: string | Date | null;
-  discordLinked?: boolean;
 }

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -1,4 +1,4 @@
-import { FormHelperText, TextField } from "@mui/material";
+import { Alert, FormHelperText, TextField } from "@mui/material";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
@@ -7,15 +7,15 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { enqueueSnackbar, SnackbarProvider } from "notistack";
 import * as React from "react";
-import type { UserData } from "@/classes/types/User";
 import type { FormStatus } from "@/components/Pages/Settings/Cards/Base";
 import PeriodSelectorOptions from "@/components/PeriodSelectorOptions";
+import type { UserDataGridRowType } from ".";
 import { approveAction } from "./actions/approveAction";
 
 interface ApproveRegistApplyProps {
   open: boolean;
   handleClose: () => void;
-  user: UserData | null;
+  user: UserDataGridRowType | null;
 }
 
 export default function ApproveRegistApplyDialog({
@@ -55,6 +55,11 @@ export default function ApproveRegistApplyDialog({
               width: "100%",
             }}
           >
+            {!(user?.emailVerified && user.discordLinked) && (
+              <Alert severity={"warning"} variant="outlined">
+                このユーザーはメールアドレス認証もしくはDiscord認証が済んでいません。
+              </Alert>
+            )}
             <DialogContentText>
               下記の情報を入力後、承認ボタンを押してください。
             </DialogContentText>

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -56,9 +56,12 @@ export default function ApproveRegistApplyDialog({
             }}
           >
             {!(user?.emailVerified && user.discordLinked) && (
-              <Alert severity={"warning"} variant="outlined">
-                このユーザーはメールアドレス認証もしくはDiscord認証が済んでいません。
-              </Alert>
+              <>
+                <Alert severity={"warning"} variant="outlined">
+                  このユーザーはメールアドレス認証もしくはDiscord認証が済んでいません。
+                </Alert>
+                <input type="hidden" name="force" value={"true"} />
+              </>
             )}
             <DialogContentText>
               下記の情報を入力後、承認ボタンを押してください。

--- a/UniQUE-Front/src/components/DataGrids/Members/actions/approveAction.ts
+++ b/UniQUE-Front/src/components/DataGrids/Members/actions/approveAction.ts
@@ -35,6 +35,7 @@ export const approveAction = async (
       message: "メールアドレスが無効です。",
     };
   }
+  const force = formData?.get("force");
   try {
     const user = await User.getById(userId);
     if (!user) {
@@ -47,6 +48,7 @@ export const approveAction = async (
       affiliationPeriod: period,
       sakuraEmailPassword: mailboxPassword,
       email: email,
+      force: force == "true",
     });
     return {
       status: "success",

--- a/UniQUE-Front/src/components/DataGrids/Members/index.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/index.tsx
@@ -32,6 +32,10 @@ import {
 } from "@/constants/UserConstants";
 import { updateUserById } from "./actions/updateAction";
 
+export interface UserDataGridRowType extends UserData {
+  discordLinked?: boolean;
+}
+
 export default function MembersDataGrid({
   rows,
   beforeJoined = false,
@@ -39,7 +43,7 @@ export default function MembersDataGrid({
   canUpdate = false,
   canRead = false,
 }: {
-  rows: UserData[];
+  rows: UserDataGridRowType[];
   beforeJoined?: boolean;
   canDelete?: boolean;
   canUpdate?: boolean;
@@ -65,17 +69,19 @@ export default function MembersDataGrid({
       })),
     [],
   );
-  const [localRows, setLocalRows] = React.useState<UserData[]>(rows);
+  const [localRows, setLocalRows] = React.useState<UserDataGridRowType[]>(rows);
   React.useEffect(() => {
     setLocalRows(rows);
   }, [rows]);
 
   const [approveDialogOpen, setApproveDialogOpen] = React.useState(false);
-  const [approvedUser, setApprovedUser] = React.useState<UserData | null>(null);
+  const [approvedUser, setApprovedUser] =
+    React.useState<UserDataGridRowType | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [deletedUserId, setDeletedUserId] = React.useState<null | string>(null);
   const [rejectDialogOpen, setRejectDialogOpen] = React.useState(false);
-  const [rejectUser, setRejectUser] = React.useState<UserData | null>(null);
+  const [rejectUser, setRejectUser] =
+    React.useState<UserDataGridRowType | null>(null);
   const unsavedChangesRef = React.useRef<{
     unsavedRows: Record<GridRowId, GridValidRowModel>;
     rowsBeforeChange: Record<GridRowId, GridValidRowModel>;
@@ -100,14 +106,11 @@ export default function MembersDataGrid({
               width: 140,
               getActions: ({ id }: { id: GridRowId }) => {
                 const user = localRows.find((u) => String(u.id) === String(id));
-                const canApprove =
-                  user?.emailVerified === true && user?.discordLinked === true;
                 return [
                   <GridActionsCellItem
                     key={"approve"}
                     icon={<CheckIcon />}
                     label="Approve"
-                    disabled={!canApprove}
                     onClick={() => {
                       setApprovedUser(user || null);
                       setApproveDialogOpen(true);
@@ -283,19 +286,13 @@ export default function MembersDataGrid({
               field: "emailVerified",
               headerName: "メール認証",
               width: 120,
-              renderCell: (params) => {
-                const verified = params.row.emailVerified === true;
-                return verified ? "✓ 認証済み" : "✗ 未認証";
-              },
+              type: "boolean",
             } as GridColDef,
             {
               field: "discordLinked",
               headerName: "Discord連携",
               width: 120,
-              renderCell: (params) => {
-                const linked = params.row.discordLinked === true;
-                return linked ? "✓ 連携済み" : "✗ 未連携";
-              },
+              type: "boolean",
             } as GridColDef,
           ]
         : []),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ユーザー承認に「強制承認（force）」オプションを追加

* **改善**
  * 承認前にメール確認とDiscord連携のチェックを行うよう強化（強制承認でスキップ可）
  * 承認ダイアログで未検証項目に対する注意表示を追加
  * メンバー一覧の認証ステータス表示を真偽値で分かりやすく改善
  * 承認操作を常に実行できるようUIの挙動を調整
  * フロント側の型定義を整理して承認処理との整合性を向上
<!-- end of auto-generated comment: release notes by coderabbit.ai -->