### PR TITLE
管理者によるパスワードリセットとプロフィール編集機能を実装する

### DIFF
--- a/UniQUE-Front/src/app/dashboard/members/[id]/page.tsx
+++ b/UniQUE-Front/src/app/dashboard/members/[id]/page.tsx
@@ -29,7 +29,9 @@ export default async function UserDetailPage({
   }
 
   const currentUser = await (await Session.getCurrent())?.getUser();
-  const canUpdate = await currentUser?.hasPermission(PermissionBitsFields.USER_UPDATE);
+  const canUpdate = await currentUser?.hasPermission(
+    PermissionBitsFields.USER_UPDATE,
+  );
 
   const userData = user.toJson();
   return (

--- a/UniQUE-Front/src/app/dashboard/members/[id]/page.tsx
+++ b/UniQUE-Front/src/app/dashboard/members/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation";
+import { Session } from "@/classes/Session";
 import { User } from "@/classes/User";
 import Profile from "@/components/Cards/Profile";
+import { PermissionBitsFields } from "@/constants/Permission";
 
 export const metadata = {
   title: "ユーザー詳細",
@@ -26,6 +28,15 @@ export default async function UserDetailPage({
     notFound();
   }
 
+  const currentUser = await (await Session.getCurrent())?.getUser();
+  const canUpdate = await currentUser?.hasPermission(PermissionBitsFields.USER_UPDATE);
+
   const userData = user.toJson();
-  return <Profile user={userData} variant="detail" showTimestamps />;
+  return (
+    <Profile
+      user={userData}
+      variant={canUpdate ? "admin" : "detail"}
+      showTimestamps
+    />
+  );
 }

--- a/UniQUE-Front/src/classes/User.ts
+++ b/UniQUE-Front/src/classes/User.ts
@@ -423,7 +423,7 @@ export class User {
     newPassword: string,
   ): Promise<void> {
     const response = await apiPut(`/users/${this.id}/password/change`, {
-      currentPassword,
+      currentPassword: currentPassword ? currentPassword : undefined,
       newPassword,
     });
     if (!response.ok) {

--- a/UniQUE-Front/src/classes/User.ts
+++ b/UniQUE-Front/src/classes/User.ts
@@ -419,7 +419,7 @@ export class User {
   }
 
   async changePassword(
-    currentPassword: string,
+    currentPassword: string | null,
     newPassword: string,
   ): Promise<void> {
     const response = await apiPut(`/users/${this.id}/password/change`, {

--- a/UniQUE-Front/src/components/Cards/Profile/index.tsx
+++ b/UniQUE-Front/src/components/Cards/Profile/index.tsx
@@ -54,7 +54,7 @@ export default function Profile({
         }}
       >
         <Box>
-          {variant === "detail" && (
+          {(variant === "detail" || variant === "admin") && (
             <Button
               startIcon={<ArrowBackIcon />}
               onClick={() => {
@@ -353,13 +353,15 @@ export default function Profile({
           </Typography>
         )}
       </Box>
-      <PasswordResetAdmin
-        open={passwordResetOpen}
-        userId={user.id}
-        onClose={() => {
-          setPasswordResetOpen(false);
-        }}
-      />
+      <SnackbarProvider>
+        <PasswordResetAdmin
+          open={passwordResetOpen}
+          userId={user.id}
+          onClose={() => {
+            setPasswordResetOpen(false);
+          }}
+        />
+      </SnackbarProvider>
     </Stack>
   );
 }

--- a/UniQUE-Front/src/components/Cards/Profile/index.tsx
+++ b/UniQUE-Front/src/components/Cards/Profile/index.tsx
@@ -7,6 +7,7 @@ import {
   CalendarToday as CalendarIcon,
   Edit as EditIcon,
   Email as EmailIcon,
+  Password,
   Person as PersonIcon,
   Web as WebIcon,
   X as XIcon,
@@ -16,6 +17,7 @@ import { useRouter } from "next/navigation";
 import { SnackbarProvider } from "notistack";
 import { useState } from "react";
 import { type UserData, UserStatus } from "@/classes/types/User";
+import PasswordResetAdmin from "@/components/Dialogs/PasswordResetAdmin";
 import ProfileEditForm from "@/components/Forms/ProfileEditForm";
 import {
   getAffiliationPeriodLabel,
@@ -24,9 +26,7 @@ import {
 
 interface ProfileProps {
   user: UserData;
-  /** 'self' は編集ボタン表示など自分用の表示。'detail' は戻るボタンなど管理者向けの表示 */
-  variant?: "self" | "detail";
-  onEdit?: () => void;
+  variant?: "self" | "detail" | "admin";
   onBack?: () => void;
   showTimestamps?: boolean;
 }
@@ -40,10 +40,9 @@ export default function Profile({
   const router = useRouter();
 
   const [userProfile, setUserProfile] = useState(user.profile);
-
   const hasFullData = user?.email !== undefined || user?.status !== undefined;
-
   const [editMode, setEditMode] = useState(false);
+  const [passwordResetOpen, setPasswordResetOpen] = useState(false);
 
   return (
     <Stack spacing={3}>
@@ -88,13 +87,22 @@ export default function Profile({
           )}
         </Box>
 
-        {variant === "self" && (
+        {(variant === "self" || variant === "admin") && (
           <Button
             variant="contained"
             startIcon={<EditIcon />}
             onClick={() => setEditMode(true)}
           >
             編集
+          </Button>
+        )}
+        {variant === "admin" && (
+          <Button
+            variant={"contained"}
+            startIcon={<Password />}
+            onClick={() => setPasswordResetOpen(true)}
+          >
+            パスワードリセット
           </Button>
         )}
       </Box>
@@ -345,6 +353,13 @@ export default function Profile({
           </Typography>
         )}
       </Box>
+      <PasswordResetAdmin
+        open={passwordResetOpen}
+        userId={user.id}
+        onClose={() => {
+          setPasswordResetOpen(false);
+        }}
+      />
     </Stack>
   );
 }

--- a/UniQUE-Front/src/components/Dialogs/PasswordResetAdmin/action.ts
+++ b/UniQUE-Front/src/components/Dialogs/PasswordResetAdmin/action.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { User } from "@/classes/User";
+import { ResourceApiErrors } from "@/errors/ResourceApiErrors";
+
+export const resetPassword = async (userId: string, newPassword: string) => {
+  const user = await User.getById(userId);
+  if (!user) throw ResourceApiErrors.ResourceNotFound;
+  await user.changePassword(null, newPassword);
+};

--- a/UniQUE-Front/src/components/Dialogs/PasswordResetAdmin/index.tsx
+++ b/UniQUE-Front/src/components/Dialogs/PasswordResetAdmin/index.tsx
@@ -53,7 +53,13 @@ export default function PasswordResetAdmin({
           <DialogContentText>
             パスワードをリセットするには、新しいパスワードを入力してください。
           </DialogContentText>
-          <TextField label={"新しいパスワード"} name={"newPassword"} required />
+          <TextField
+            label={"新しいパスワード"}
+            name={"newPassword"}
+            type="password"
+            autoComplete="new-password"
+            required
+          />
         </DialogContent>
         <DialogActions sx={{ pb: 3, px: 3 }}>
           <Button
@@ -64,7 +70,7 @@ export default function PasswordResetAdmin({
             キャンセル
           </Button>
           <Button variant="contained" type="submit" color="error">
-            削除
+            リセット
           </Button>
         </DialogActions>
       </form>

--- a/UniQUE-Front/src/components/Dialogs/PasswordResetAdmin/index.tsx
+++ b/UniQUE-Front/src/components/Dialogs/PasswordResetAdmin/index.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from "@mui/material";
+import { useSnackbar } from "notistack";
+import { resetPassword } from "./action";
+
+export default function PasswordResetAdmin({
+  open,
+  onClose,
+  userId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  userId: string;
+}) {
+  const { enqueueSnackbar } = useSnackbar();
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <form
+        action={async (formdata: FormData) => {
+          const newPassword = formdata.get("newPassword");
+          if (!newPassword || typeof newPassword !== "string") return;
+          try {
+            await resetPassword(userId, newPassword);
+            enqueueSnackbar("パスワードリセットを行いました。", {
+              variant: "success",
+            });
+            onClose();
+          } catch {
+            enqueueSnackbar("パスワードリセットに失敗しました。", {
+              variant: "error",
+            });
+          }
+        }}
+      >
+        <DialogContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            width: "100%",
+          }}
+        >
+          <DialogTitle>管理者によるパスワードリセット</DialogTitle>
+          <DialogContentText>
+            パスワードをリセットするには、新しいパスワードを入力してください。
+          </DialogContentText>
+          <TextField label={"新しいパスワード"} name={"newPassword"} required />
+        </DialogContent>
+        <DialogActions sx={{ pb: 3, px: 3 }}>
+          <Button
+            onClick={() => {
+              onClose();
+            }}
+          >
+            キャンセル
+          </Button>
+          <Button variant="contained" type="submit" color="error">
+            削除
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Resolve #34
Resolve #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理者向けにメンバープロフィールからのパスワードリセットUIを追加。ダイアログで新パスワードを設定可能。
  * 管理者権限がある場合、プロフィール表示が「管理者ビュー」として編集やリセット操作を行えるように動的表示。
* **変更**
  * 管理者によるパスワード更新は現在のパスワード不要で実行可能に。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->