### PR TITLE
feat: フォームの状態管理を追加して認証部分に関わる処理を強化

### DIFF
--- a/UniQUE-Front/src/components/Cards/Profile/index.tsx
+++ b/UniQUE-Front/src/components/Cards/Profile/index.tsx
@@ -89,23 +89,23 @@ export default function Profile({
 
         <Stack direction={"row"} justifyContent={"end"} gap={2}>
           {(variant === "self" || variant === "admin") && (
-          <Button
-            variant="contained"
-            startIcon={<EditIcon />}
-            onClick={() => setEditMode(true)}
-          >
-            編集
-          </Button>
-        )}
-        {variant === "admin" && (
-          <Button
-            variant={"contained"}
-            startIcon={<Password />}
-            onClick={() => setPasswordResetOpen(true)}
-          >
-            パスワードリセット
-          </Button>
-        )}
+            <Button
+              variant="contained"
+              startIcon={<EditIcon />}
+              onClick={() => setEditMode(true)}
+            >
+              編集
+            </Button>
+          )}
+          {variant === "admin" && (
+            <Button
+              variant={"contained"}
+              startIcon={<Password />}
+              onClick={() => setPasswordResetOpen(true)}
+            >
+              パスワードリセット
+            </Button>
+          )}
         </Stack>
       </Box>
 

--- a/UniQUE-Front/src/components/Pages/Authentication/components/Cards/MigrationCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/Cards/MigrationCard/index.tsx
@@ -35,8 +35,10 @@ export default function MigrationCard() {
     React.useState("");
   const [agreeTosError, setAgreeTosError] = React.useState(false);
   const [agreeTosErrorMessage, setAgreeTosErrorMessage] = React.useState("");
+  const [inProgress, setInProgress] = React.useState(false);
 
   const validateInputs = () => {
+    setInProgress(true);
     const email = document.getElementById("email") as HTMLInputElement;
     const password = document.getElementById("password") as HTMLInputElement;
     const confirmPassword = document.getElementById(
@@ -108,6 +110,8 @@ export default function MigrationCard() {
       );
     }
 
+    if (!isValid) setInProgress(false);
+
     return isValid;
   };
 
@@ -143,7 +147,11 @@ export default function MigrationCard() {
         component="form"
         noValidate
         sx={{ display: "flex", flexDirection: "column", width: "100%", gap: 2 }}
-        action={submitMigration}
+        action={async (formdata: FormData) => {
+          setInProgress(true);
+          await submitMigration(formdata);
+          setInProgress(false);
+        }}
       >
         <FormControl>
           <FormLabel htmlFor="name">お名前</FormLabel>
@@ -264,8 +272,9 @@ export default function MigrationCard() {
           fullWidth
           variant="contained"
           onClick={validateInputs}
+          disabled={inProgress}
         >
-          サインアップ
+          {!inProgress ? "アカウントを移行" : "アカウントを移行中..."}
         </Button>
       </Box>
     </Card>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/Cards/MigrationCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/Cards/MigrationCard/index.tsx
@@ -271,7 +271,9 @@ export default function MigrationCard() {
           type="submit"
           fullWidth
           variant="contained"
-          onClick={validateInputs}
+          onClick={(e) => {
+            if (!validateInputs()) e.preventDefault();  
+          }}
           disabled={inProgress}
         >
           {!inProgress ? "アカウントを移行" : "アカウントを移行中..."}

--- a/UniQUE-Front/src/components/Pages/Authentication/components/Cards/MultiFactorCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/Cards/MultiFactorCard/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import FormControl from "@mui/material/FormControl";
@@ -5,6 +6,7 @@ import FormLabel from "@mui/material/FormLabel";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { RedirectType, redirect } from "next/navigation";
+import { useState } from "react";
 import { useInitialFormState, useRedirectTo } from "../../../Client";
 import { submitSignIn } from "../../actions/signIn";
 import { SitemarkIcon } from "../../CustomIcons";
@@ -13,6 +15,8 @@ import { Card } from "../Base";
 export default function MultiFactorCard() {
   const initialState = useInitialFormState();
   const redirectTo = useRedirectTo();
+
+  const [inProgress, setInProgress] = useState(false);
 
   return (
     <Card variant="outlined">
@@ -31,10 +35,12 @@ export default function MultiFactorCard() {
         noValidate
         sx={{ display: "flex", flexDirection: "column", width: "100%", gap: 2 }}
         action={async (data: FormData) => {
+          setInProgress(true);
           const result = await submitSignIn(data);
           if (result.redirectTo) {
             redirect(result.redirectTo, RedirectType.push);
           }
+          setInProgress(false);
         }}
       >
         <input type="hidden" name="redirectTo" value={redirectTo} />
@@ -79,8 +85,13 @@ export default function MultiFactorCard() {
           name="remember"
           value={initialState?.rememberMe ? "on" : "off"}
         />
-        <Button type="submit" fullWidth variant="contained">
-          サインイン
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          disabled={inProgress}
+        >
+          {!inProgress ? "サインイン" : "サインイン中..."}
         </Button>
       </Box>
     </Card>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/Cards/SignInCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/Cards/SignInCard/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
@@ -23,17 +24,20 @@ export default function SignUpCard() {
   const [passwordError, setPasswordError] = React.useState(false);
   const [passwordErrorMessage, setPasswordErrorMessage] = React.useState("");
 
-  const [open, setOpen] = React.useState(false);
+  const [forgotPasswordOpen, setForgotPasswordOpen] = React.useState(false);
+
+  const [inProgress, setInProgress] = React.useState(false);
 
   const handleClickOpen = () => {
-    setOpen(true);
+    setForgotPasswordOpen(true);
   };
 
   const handleClose = () => {
-    setOpen(false);
+    setForgotPasswordOpen(false);
   };
 
   const validateInputs = () => {
+    setInProgress(false);
     const password = document.getElementById("password") as HTMLInputElement;
 
     let isValid = true;
@@ -46,6 +50,8 @@ export default function SignUpCard() {
       setPasswordError(false);
       setPasswordErrorMessage("");
     }
+
+    if (!isValid) setInProgress(false);
 
     return isValid;
   };
@@ -83,10 +89,12 @@ export default function SignUpCard() {
         noValidate
         sx={{ display: "flex", flexDirection: "column", width: "100%", gap: 2 }}
         action={async (data: FormData) => {
+          setInProgress(true);
           const result = await submitSignIn(data);
           if (result.redirectTo) {
             redirect(result.redirectTo, RedirectType.push);
           }
+          setInProgress(false);
         }}
       >
         <input
@@ -118,6 +126,7 @@ export default function SignUpCard() {
               type="button"
               onClick={handleClickOpen}
               variant="body2"
+              disabled={inProgress}
               sx={{ alignSelf: "baseline" }}
             >
               パスワードをお忘れですか？
@@ -147,12 +156,13 @@ export default function SignUpCard() {
           fullWidth
           variant="contained"
           onClick={validateInputs}
+          disabled={inProgress}
         >
-          サインイン
+          {!inProgress ? "サインイン" : "サインイン中..."}
         </Button>
       </Box>
       <SnackbarProvider maxSnack={3} autoHideDuration={6000}>
-        <ForgotPassword open={open} handleClose={handleClose} />
+        <ForgotPassword open={forgotPasswordOpen} handleClose={handleClose} />
       </SnackbarProvider>
     </Card>
   );

--- a/UniQUE-Front/src/components/Pages/Authentication/components/Cards/SignInCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/Cards/SignInCard/index.tsx
@@ -37,7 +37,7 @@ export default function SignUpCard() {
   };
 
   const validateInputs = () => {
-    setInProgress(false);
+    setInProgress(true);
     const password = document.getElementById("password") as HTMLInputElement;
 
     let isValid = true;

--- a/UniQUE-Front/src/components/Pages/Authentication/components/Cards/SignUpCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/Cards/SignUpCard/index.tsx
@@ -30,8 +30,10 @@ export default function SignUpCard() {
   );
   const [agreeTosError, setAgreeTosError] = React.useState(false);
   const [agreeTosErrorMessage, setAgreeTosErrorMessage] = React.useState("");
+  const [inProgress, setInProgress] = React.useState(false);
 
   const validateInputs = () => {
+    setInProgress(true);
     const email = document.getElementById("email") as HTMLInputElement;
     const password = document.getElementById("password") as HTMLInputElement;
     const confirmPassword = document.getElementById(
@@ -120,7 +122,7 @@ export default function SignUpCard() {
         "利用規約、プライバシーポリシー、サークル規約に同意してください。",
       );
     }
-
+    if (!isValid) setInProgress(false);
     return isValid;
   };
 
@@ -156,7 +158,11 @@ export default function SignUpCard() {
         component="form"
         noValidate
         sx={{ display: "flex", flexDirection: "column", width: "100%", gap: 2 }}
-        action={submitSignUp}
+        action={async (formdata: FormData) => {
+          setInProgress(true);
+          await submitSignUp(formdata);
+          setInProgress(false);
+        }}
       >
         <FormControl>
           <FormLabel htmlFor="name">お名前</FormLabel>
@@ -275,8 +281,9 @@ export default function SignUpCard() {
           fullWidth
           variant="contained"
           onClick={validateInputs}
+          disabled={inProgress}
         >
-          サインアップ
+          {!inProgress ? "サインアップ" : "サインアップ中..."}
         </Button>
       </Box>
     </Card>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/MigrationCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/MigrationCard/index.tsx
@@ -36,7 +36,10 @@ export default function MigrationCard() {
   const [agreeTosError, setAgreeTosError] = React.useState(false);
   const [agreeTosErrorMessage, setAgreeTosErrorMessage] = React.useState("");
 
+  const [inProgress, setInProgress] = React.useState(false);
+
   const validateInputs = () => {
+    setInProgress(true);
     const email = document.getElementById("email") as HTMLInputElement;
     const password = document.getElementById("password") as HTMLInputElement;
     const confirmPassword = document.getElementById(
@@ -108,6 +111,8 @@ export default function MigrationCard() {
       );
     }
 
+    if (!isValid) setInProgress(false);
+
     return isValid;
   };
 
@@ -133,7 +138,11 @@ export default function MigrationCard() {
             width: "100%",
             gap: 2,
           }}
-          action={submitMigration}
+          action={async (formdata: FormData) => {
+            setInProgress(true);
+            await submitMigration(formdata);
+            setInProgress(false);
+          }}
         >
           <FormControl>
             <FormLabel htmlFor="name">お名前</FormLabel>
@@ -256,8 +265,9 @@ export default function MigrationCard() {
             fullWidth
             variant="contained"
             onClick={validateInputs}
+            disabled={inProgress}
           >
-            サインアップ
+            {!inProgress ? "サインアップ" : "サインアップ中..."}
           </Button>
         </Box>
         <Divider>or</Divider>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/MultiFactorCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/MultiFactorCard/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import FormControl from "@mui/material/FormControl";
@@ -5,6 +6,7 @@ import FormLabel from "@mui/material/FormLabel";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { RedirectType, redirect } from "next/navigation";
+import { useState } from "react";
 import { useInitialFormState, useRedirectTo } from "../../../Client";
 import { submitSignIn } from "../../actions/signIn";
 import { SitemarkIcon } from "../../CustomIcons";
@@ -13,6 +15,8 @@ import { Card } from "../Base";
 export default function MultiFactorCard() {
   const initialState = useInitialFormState();
   const redirectTo = useRedirectTo();
+
+  const [inProgress, setInProgress] = useState(false);
 
   return (
     <Card variant="outlined">
@@ -31,10 +35,12 @@ export default function MultiFactorCard() {
         noValidate
         sx={{ display: "flex", flexDirection: "column", width: "100%", gap: 2 }}
         action={async (data: FormData) => {
+          setInProgress(true);
           const result = await submitSignIn(data);
           if (result.redirectTo) {
             redirect(result.redirectTo, RedirectType.push);
           }
+          setInProgress(false);
         }}
       >
         <input type="hidden" name="redirectTo" value={redirectTo} />
@@ -79,8 +85,13 @@ export default function MultiFactorCard() {
           name="remember"
           value={initialState?.rememberMe ? "on" : "off"}
         />
-        <Button type="submit" variant="contained" fullWidth>
-          サインイン
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          disabled={inProgress}
+        >
+          {!inProgress ? "サインイン" : "サインイン中..."}
         </Button>
       </Box>
     </Card>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/SignInCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/SignInCard/index.tsx
@@ -22,7 +22,10 @@ export default function SignInCard() {
   const [passwordError, setPasswordError] = React.useState(false);
   const [passwordErrorMessage, setPasswordErrorMessage] = React.useState("");
 
+  const [inProgress, setInProgress] = React.useState(false);
+
   const validateInputs = () => {
+    setInProgress(true);
     const password = document.getElementById("password") as HTMLInputElement;
 
     let isValid = true;
@@ -35,6 +38,8 @@ export default function SignInCard() {
       setPasswordError(false);
       setPasswordErrorMessage("");
     }
+
+    if (!isValid) setInProgress(false);
 
     return isValid;
   };
@@ -56,10 +61,12 @@ export default function SignInCard() {
         noValidate
         sx={{ display: "flex", flexDirection: "column", width: "100%", gap: 2 }}
         action={async (data: FormData) => {
+          setInProgress(true);
           const result = await submitSignIn(data);
           if (result.redirectTo) {
             redirect(result.redirectTo, RedirectType.push);
           }
+          setInProgress(false);
         }}
       >
         <input
@@ -111,8 +118,9 @@ export default function SignInCard() {
           fullWidth
           variant="contained"
           onClick={validateInputs}
+          disabled={inProgress}
         >
-          サインイン
+          {inProgress ? "サインイン" : "サインイン中..."}
         </Button>
       </Box>
       <Divider>or</Divider>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/SignInCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/SignInCard/index.tsx
@@ -120,7 +120,7 @@ export default function SignInCard() {
           onClick={validateInputs}
           disabled={inProgress}
         >
-          {inProgress ? "サインイン" : "サインイン中..."}
+          {!inProgress ? "サインイン" : "サインイン中..."}
         </Button>
       </Box>
       <Divider>or</Divider>

--- a/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/SignUpCard/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Authentication/components/MobileCards/SignUpCard/index.tsx
@@ -33,7 +33,10 @@ export default function SignUpCard() {
   const [agreeTosError, setAgreeTosError] = React.useState(false);
   const [agreeTosErrorMessage, setAgreeTosErrorMessage] = React.useState("");
 
+  const [inProgress, setInProgress] = React.useState(false);
+
   const validateInputs = () => {
+    setInProgress(true);
     const email = document.getElementById("email") as HTMLInputElement;
     const password = document.getElementById("password") as HTMLInputElement;
     const confirmPassword = document.getElementById(
@@ -123,6 +126,8 @@ export default function SignUpCard() {
       );
     }
 
+    if (!isValid) setInProgress(false);
+
     return isValid;
   };
 
@@ -148,7 +153,11 @@ export default function SignUpCard() {
             width: "100%",
             gap: 2,
           }}
-          action={submitSignUp}
+          action={async (formdata: FormData) => {
+            setInProgress(true);
+            await submitSignUp(formdata);
+            setInProgress(false);
+          }}
         >
           <FormControl>
             <FormLabel htmlFor="name">お名前</FormLabel>
@@ -269,8 +278,9 @@ export default function SignUpCard() {
             fullWidth
             variant="contained"
             onClick={validateInputs}
+            disabled={inProgress}
           >
-            サインアップ
+            {!inProgress ? "サインアップ" : "サインアップ中..."}
           </Button>
         </Box>
         <Divider>or</Divider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 認証フォーム（サインイン、サインアップ、多要素認証、マイグレーション）の送信進行表示を統一導入。送信中はボタンが無効化され、ラベルが進行中表示に切替わります。Forgot Passwordリンクも送信中は無効化されます。

* **バグ修正**
  * プロフィールカードの右上アクションボタンのレイアウトを修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->