### PR TITLE
メンバー登録申請承認時に内部メールアドレスを事前に入力する

### DIFF
--- a/UniQUE-Front/src/app/dashboard/requests/page.tsx
+++ b/UniQUE-Front/src/app/dashboard/requests/page.tsx
@@ -39,7 +39,7 @@ export default async function Page() {
         <Typography variant="h5">メンバー申請一覧</Typography>
         <Typography variant="body1">メンバー申請一覧です。</Typography>
       </Stack>
-      <MembersDataGrid rows={rows} beforeJoined />
+      <MembersDataGrid rows={rows} beforeJoined canRead={true} />
     </Stack>
   );
 }

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -35,7 +35,6 @@ export default function ApproveRegistApplyDialog({
   }, [open]);
 
   const [state, action, isPending] = React.useActionState(
-  const [state, action, isPending] = React.useActionState(
     approveAction,
     null as null | FormStatus,
   );
@@ -93,20 +92,11 @@ export default function ApproveRegistApplyDialog({
               required
               fullWidth
               variant="outlined"
-             <TextField
-               label="メールアドレス"
-               type="email"
-               name="email"
-               required
-               fullWidth
-               variant="outlined"
-               value={email}
-               onChange={(e) => {
-                 setEmail(e.target.value);
-                 setIsManual(true);
-               }}
-               placeholder="メールアドレスを入力してください"
-             />
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setIsManual(true);
+              }}
               placeholder="メールアドレスを入力してください"
             />
             <FormHelperText>

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -93,8 +93,20 @@ export default function ApproveRegistApplyDialog({
               required
               fullWidth
               variant="outlined"
-              value={!isManual ? email : undefined}
-              onChange={(_) => setIsManual(true)}
+             <TextField
+               label="メールアドレス"
+               type="email"
+               name="email"
+               required
+               fullWidth
+               variant="outlined"
+               value={email}
+               onChange={(e) => {
+                 setEmail(e.target.value);
+                 setIsManual(true);
+               }}
+               placeholder="メールアドレスを入力してください"
+             />
               placeholder="メールアドレスを入力してください"
             />
             <FormHelperText>

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -26,6 +26,15 @@ export default function ApproveRegistApplyDialog({
 }: ApproveRegistApplyProps) {
   const [email, setEmail] = React.useState("");
   const [isManual, setIsManual] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) {
+      setEmail("");
+      setIsManual(false);
+    }
+  }, [open]);
+
+  const [state, action, isPending] = React.useActionState(
   const [state, action, isPending] = React.useActionState(
     approveAction,
     null as null | FormStatus,

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Alert, FormHelperText, TextField } from "@mui/material";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -23,6 +24,8 @@ export default function ApproveRegistApplyDialog({
   handleClose,
   user,
 }: ApproveRegistApplyProps) {
+  const [email, setEmail] = React.useState("");
+  const [isManual, setIsManual] = React.useState(false);
   const [state, action, isPending] = React.useActionState(
     approveAction,
     null as null | FormStatus,
@@ -67,7 +70,13 @@ export default function ApproveRegistApplyDialog({
               下記の情報を入力後、承認ボタンを押してください。
             </DialogContentText>
             <input type="hidden" name="userId" value={user?.id || ""} />
-            <PeriodSelectorOptions />
+            <PeriodSelectorOptions
+              onChange={(e) =>
+                setEmail(
+                  `${e.target.value as string}.${user?.customId}@uniproject.jp`,
+                )
+              }
+            />
             <TextField
               label="メールアドレス"
               type="email"
@@ -75,8 +84,9 @@ export default function ApproveRegistApplyDialog({
               required
               fullWidth
               variant="outlined"
+              value={!isManual ? email : undefined}
+              onChange={(_) => setIsManual(true)}
               placeholder="メールアドレスを入力してください"
-              defaultValue={user?.email || ""}
             />
             <FormHelperText>
               メールアドレスはtemp_を削除し、(所属期).xxxxx@uniproject.jpの形式としてください。

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -79,11 +79,13 @@ export default function ApproveRegistApplyDialog({
             </DialogContentText>
             <input type="hidden" name="userId" value={user?.id || ""} />
             <PeriodSelectorOptions
-              onChange={(e) =>
-                setEmail(
-                  `${e.target.value as string}.${user?.customId}@uniproject.jp`,
-                )
-              }
+              onChange={(e) => {
+                if (!isManual && user) {
+                  setEmail(
+                    `${e.target.value as string}.${user?.customId}@uniproject.jp`,
+                  );
+                }
+              }}
             />
             <TextField
               label="メールアドレス"

--- a/UniQUE-Front/src/components/DataGrids/Members/actions/approveAction.ts
+++ b/UniQUE-Front/src/components/DataGrids/Members/actions/approveAction.ts
@@ -48,7 +48,7 @@ export const approveAction = async (
       affiliationPeriod: period,
       sakuraEmailPassword: mailboxPassword,
       email: email,
-      force: force == "true",
+      force: force === "true",
     });
     return {
       status: "success",

--- a/UniQUE-Front/src/components/DataGrids/Members/actions/approveAction.ts
+++ b/UniQUE-Front/src/components/DataGrids/Members/actions/approveAction.ts
@@ -61,5 +61,4 @@ export const approveAction = async (
       message: "メンバーの承認に失敗しました。",
     };
   }
-  return null;
 };

--- a/UniQUE-Front/src/components/PeriodSelectorOptions.tsx
+++ b/UniQUE-Front/src/components/PeriodSelectorOptions.tsx
@@ -7,7 +7,7 @@ import {
   Select,
   Typography,
 } from "@mui/material";
-import { useMemo } from "react";
+import { type ChangeEvent, useMemo } from "react";
 import {
   getAffiliationPeriodInfo,
   getSelectableAffiliationPeriods,
@@ -18,7 +18,23 @@ import {
  *　所属期の選択肢を生成するコンポーネント
  * @returns React.JSX 所属期のMenuItem
  */
-export default function PeriodSelectorOptions() {
+export default function PeriodSelectorOptions({
+  onChange,
+}: {
+  onChange?:
+    | ((
+        event:
+          | ChangeEvent<HTMLInputElement, Element>
+          | (Event & {
+              target: {
+                value: unknown;
+                name: string;
+              };
+            }),
+        child: React.ReactNode,
+      ) => void)
+    | undefined;
+}) {
   // 所属期のオプション配列をメモ化
   const affiliationPeriodValueOptionsArray = useMemo(
     () => getSelectableAffiliationPeriods(),
@@ -39,6 +55,7 @@ export default function PeriodSelectorOptions() {
         variant="outlined"
         required
         sx={{ display: "flex", flexDirection: "row" }}
+        onChange={onChange}
       >
         {affiliationPeriodValueOptionsArray.map((p) => {
           const period = p.value;

--- a/UniQUE-Front/src/components/PeriodSelectorOptions.tsx
+++ b/UniQUE-Front/src/components/PeriodSelectorOptions.tsx
@@ -5,9 +5,10 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  type SelectChangeEvent,
   Typography,
 } from "@mui/material";
-import { type ChangeEvent, useMemo } from "react";
+import { useMemo } from "react";
 import {
   getAffiliationPeriodInfo,
   getSelectableAffiliationPeriods,
@@ -22,17 +23,7 @@ export default function PeriodSelectorOptions({
   onChange,
 }: {
   onChange?:
-    | ((
-        event:
-          | ChangeEvent<HTMLInputElement, Element>
-          | (Event & {
-              target: {
-                value: unknown;
-                name: string;
-              };
-            }),
-        child: React.ReactNode,
-      ) => void)
+    | ((event: SelectChangeEvent, child: React.ReactNode) => void)
     | undefined;
 }) {
   // 所属期のオプション配列をメモ化


### PR DESCRIPTION
Fixes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 承認ダイアログのメールフィールドが選択した期間に基づいて動的に更新されるように改善しました
  * ユーザーはメール入力フィールドを手動で編集できるようになりました

* **リファクタリング**
  * 承認処理の不要なコード行を削除して最適化しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniPro-tech/UniQUE/pull/50)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->