### PR TITLE
fix: メンバー承認ダイアログのメールアドレス入力を小文字に統一

### DIFF
--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -81,9 +81,8 @@ export default function ApproveRegistApplyDialog({
             <PeriodSelectorOptions
               onChange={(e) => {
                 if (!isManual && user) {
-                  setEmail(
-                    `${e.target.value as string}.${user?.customId}@uniproject.jp`,
-                  );
+                  const generatedEmail =`${e.target.value as string}.${user?.customId}@uniproject.jp`;
+                  setEmail(generatedEmail.toLowerCase());
                 }
               }}
             />
@@ -96,7 +95,7 @@ export default function ApproveRegistApplyDialog({
               variant="outlined"
               value={email}
               onChange={(e) => {
-                setEmail(e.target.value);
+                setEmail(e.target.value.toLowerCase());
                 setIsManual(true);
               }}
               placeholder="メールアドレスを入力してください"


### PR DESCRIPTION
## 概要
`UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx` のメールアドレス入力において、大文字が許容されてしまっている問題を修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* メールアドレス入力の大文字小文字を統一するように改善しました。登録期間から自動生成されたメールアドレス、およびユーザーが手動で編集した場合のいずれでも、メールアドレスが小文字に統一されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniPro-tech/UniQUE/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->