### PR TITLE
登録申請承認・却下時にrowから消す処理を追加

### DIFF
--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -17,12 +17,14 @@ interface ApproveRegistApplyProps {
   open: boolean;
   handleClose: () => void;
   user: UserDataGridRowType | null;
+  deleteRowAction: (userId: string) => void;
 }
 
 export default function ApproveRegistApplyDialog({
   open,
   handleClose,
   user,
+  deleteRowAction,
 }: ApproveRegistApplyProps) {
   const [email, setEmail] = React.useState("");
   const [isManual, setIsManual] = React.useState(false);
@@ -56,7 +58,13 @@ export default function ApproveRegistApplyDialog({
           },
         }}
       >
-        <form action={action} id="approve-regist-apply-data-dialog">
+        <form
+          action={async (formdata: FormData) => {
+            action(formdata);
+            deleteRowAction(formdata.get("userId") as string);
+          }}
+          id="approve-regist-apply-data-dialog"
+        >
           <DialogTitle>メンバーの承認</DialogTitle>
           <DialogContent
             sx={{
@@ -81,7 +89,7 @@ export default function ApproveRegistApplyDialog({
             <PeriodSelectorOptions
               onChange={(e) => {
                 if (!isManual && user) {
-                  const generatedEmail =`${e.target.value as string}.${user?.customId}@uniproject.jp`;
+                  const generatedEmail = `${e.target.value as string}.${user?.customId}@uniproject.jp`;
                   setEmail(generatedEmail.toLowerCase());
                 }
               }}

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -40,16 +40,24 @@ export default function ApproveRegistApplyDialog({
     approveAction,
     null as null | FormStatus,
   );
+
+  const submittingUserIdRef = React.useRef<string | null>(null);
+  const handleSubmit = React.useCallback(() => {
+    if (user) {
+      submittingUserIdRef.current = user.id;
+    }
+  }, [user]);
   React.useEffect(() => {
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
       if (state.status === "success") {
-        if (!user) return;
-        deleteRowAction(user.id);
+        const userId = submittingUserIdRef.current;
+        if (!userId) return;
+        deleteRowAction(userId);
         handleClose();
       }
     }
-  }, [handleClose, state, deleteRowAction, user]);
+  }, [handleClose, state, deleteRowAction]);
 
   return (
     <SnackbarProvider maxSnack={3} autoHideDuration={6000}>
@@ -62,7 +70,11 @@ export default function ApproveRegistApplyDialog({
           },
         }}
       >
-        <form action={action} id="approve-regist-apply-data-dialog">
+        <form
+          action={action}
+          onSubmit={handleSubmit}
+          id="approve-regist-apply-data-dialog"
+        >
           <DialogTitle>メンバーの承認</DialogTitle>
           <DialogContent
             sx={{

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -43,9 +43,13 @@ export default function ApproveRegistApplyDialog({
   React.useEffect(() => {
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
-      handleClose();
+      if (state.status === "success") {
+        // biome-ignore lint/style/noNonNullAssertion: 上流で保証されている
+        deleteRowAction(user!.id);
+        handleClose();
+      }
     }
-  }, [handleClose, state]);
+  }, [handleClose, state, deleteRowAction, user?.id]);
 
   return (
     <SnackbarProvider maxSnack={3} autoHideDuration={6000}>
@@ -58,13 +62,7 @@ export default function ApproveRegistApplyDialog({
           },
         }}
       >
-        <form
-          action={async (formdata: FormData) => {
-            action(formdata);
-            deleteRowAction(formdata.get("userId") as string);
-          }}
-          id="approve-regist-apply-data-dialog"
-        >
+        <form action={action} id="approve-regist-apply-data-dialog">
           <DialogTitle>メンバーの承認</DialogTitle>
           <DialogContent
             sx={{
@@ -85,7 +83,8 @@ export default function ApproveRegistApplyDialog({
             <DialogContentText>
               下記の情報を入力後、承認ボタンを押してください。
             </DialogContentText>
-            <input type="hidden" name="userId" value={user?.id || ""} />
+            {/** biome-ignore lint/style/noNonNullAssertion: 上流で保証されている */}
+            <input type="hidden" name="userId" value={user!.id} />
             <PeriodSelectorOptions
               onChange={(e) => {
                 if (!isManual && user) {

--- a/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/ApproveDialog.tsx
@@ -44,12 +44,12 @@ export default function ApproveRegistApplyDialog({
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
       if (state.status === "success") {
-        // biome-ignore lint/style/noNonNullAssertion: 上流で保証されている
-        deleteRowAction(user!.id);
+        if (!user) return;
+        deleteRowAction(user.id);
         handleClose();
       }
     }
-  }, [handleClose, state, deleteRowAction, user?.id]);
+  }, [handleClose, state, deleteRowAction, user]);
 
   return (
     <SnackbarProvider maxSnack={3} autoHideDuration={6000}>

--- a/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
@@ -30,9 +30,11 @@ export default function RejectDialog({
   React.useEffect(() => {
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
-      // biome-ignore lint/style/noNonNullAssertion: 上流で保証されている
-      deleteRowAction(user!.id);
-      handleClose();
+      if (state.status === "success") {
+        // biome-ignore lint/style/noNonNullAssertion: 上流で保証されている
+        deleteRowAction(user!.id);
+        handleClose();
+      }
     }
   }, [handleClose, state, deleteRowAction, user?.id]);
 

--- a/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
@@ -31,12 +31,12 @@ export default function RejectDialog({
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
       if (state.status === "success") {
-        // biome-ignore lint/style/noNonNullAssertion: 上流で保証されている
-        deleteRowAction(user!.id);
+        if (!user) return;
+        deleteRowAction(user.id);
         handleClose();
       }
     }
-  }, [handleClose, state, deleteRowAction, user?.id]);
+  }, [handleClose, state, deleteRowAction, user]);
 
   return (
     <SnackbarProvider maxSnack={3} autoHideDuration={6000}>

--- a/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
@@ -10,17 +10,19 @@ import type { UserData } from "@/classes/types/User";
 import type { FormStatus } from "@/components/Pages/Settings/Cards/Base";
 import { rejectRegistApplyAction } from "./actions/rejectRegistApplyAction";
 
-interface ApproveRegistApplyProps {
+interface RejectRegistApplyProps {
   open: boolean;
   handleClose: () => void;
   user: UserData | null;
+  deleteRowAction?: (userId: string) => void;
 }
 
 export default function RejectDialog({
   open,
   handleClose,
   user,
-}: ApproveRegistApplyProps) {
+  deleteRowAction,
+}: RejectRegistApplyProps) {
   const [state, action, isPending] = React.useActionState(
     rejectRegistApplyAction,
     null as null | FormStatus,
@@ -43,7 +45,14 @@ export default function RejectDialog({
           },
         }}
       >
-        <form action={action} id="reject-regist-apply-data-dialog">
+        <form
+          action={async (formdata: FormData) => {
+            action(formdata);
+            if (deleteRowAction)
+              deleteRowAction(formdata.get("userId") as string);
+          }}
+          id="reject-regist-apply-data-dialog"
+        >
           <DialogTitle>メンバーの却下</DialogTitle>
           <DialogContent
             sx={{

--- a/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
@@ -27,16 +27,26 @@ export default function RejectDialog({
     rejectRegistApplyAction,
     null as null | FormStatus,
   );
+
+  const submittingUserIdRef = React.useRef<string | null>(null);
+  const handleSubmit = React.useCallback(() => {
+    if (user) {
+      submittingUserIdRef.current = user.id;
+    }
+  }, [user]);
+
   React.useEffect(() => {
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
       if (state.status === "success") {
-        if (!user) return;
-        deleteRowAction(user.id);
+        const userId = submittingUserIdRef.current;
+        if (!userId) return;
+        deleteRowAction(userId);
+        submittingUserIdRef.current = null; // リセットして再実行を防ぐ
         handleClose();
       }
     }
-  }, [handleClose, state, deleteRowAction, user]);
+  }, [handleClose, state, deleteRowAction]);
 
   return (
     <SnackbarProvider maxSnack={3} autoHideDuration={6000}>
@@ -49,7 +59,11 @@ export default function RejectDialog({
           },
         }}
       >
-        <form action={action} id="reject-regist-apply-data-dialog">
+        <form
+          action={action}
+          id="reject-regist-apply-data-dialog"
+          onSubmit={handleSubmit}
+        >
           <DialogTitle>メンバーの却下</DialogTitle>
           <DialogContent
             sx={{

--- a/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/RejectDialog.tsx
@@ -14,7 +14,7 @@ interface RejectRegistApplyProps {
   open: boolean;
   handleClose: () => void;
   user: UserData | null;
-  deleteRowAction?: (userId: string) => void;
+  deleteRowAction: (userId: string) => void;
 }
 
 export default function RejectDialog({
@@ -30,9 +30,11 @@ export default function RejectDialog({
   React.useEffect(() => {
     if (state) {
       enqueueSnackbar(state.message, { variant: state.status });
+      // biome-ignore lint/style/noNonNullAssertion: 上流で保証されている
+      deleteRowAction(user!.id);
       handleClose();
     }
-  }, [handleClose, state]);
+  }, [handleClose, state, deleteRowAction, user?.id]);
 
   return (
     <SnackbarProvider maxSnack={3} autoHideDuration={6000}>
@@ -45,14 +47,7 @@ export default function RejectDialog({
           },
         }}
       >
-        <form
-          action={async (formdata: FormData) => {
-            action(formdata);
-            if (deleteRowAction)
-              deleteRowAction(formdata.get("userId") as string);
-          }}
-          id="reject-regist-apply-data-dialog"
-        >
+        <form action={action} id="reject-regist-apply-data-dialog">
           <DialogTitle>メンバーの却下</DialogTitle>
           <DialogContent
             sx={{
@@ -69,7 +64,8 @@ export default function RejectDialog({
               カスタムID:{" "}
               {user?.customId || user?.profile?.displayName || "不明なユーザー"}
             </DialogContentText>
-            <input type="hidden" name="userId" value={user?.id || ""} />
+            {/** biome-ignore lint/style/noNonNullAssertion: 上流で保証されている */}
+            <input type="hidden" name="userId" value={user!.id} />
           </DialogContent>
           <DialogActions sx={{ pb: 3, px: 3 }}>
             <Button onClick={handleClose} disabled={isPending}>

--- a/UniQUE-Front/src/components/DataGrids/Members/index.tsx
+++ b/UniQUE-Front/src/components/DataGrids/Members/index.tsx
@@ -508,11 +508,17 @@ export default function MembersDataGrid({
         open={approveDialogOpen}
         handleClose={() => setApproveDialogOpen(false)}
         user={approvedUser}
+        deleteRowAction={(userId: string) => {
+          apiRef.current?.updateRows([{ id: userId, _action: "delete" }]);
+        }}
       />
       <RejectDialog
         open={rejectDialogOpen}
         user={rejectUser}
         handleClose={() => setRejectDialogOpen(false)}
+        deleteRowAction={(userId: string) => {
+          apiRef.current?.updateRows([{ id: userId, _action: "delete" }]);
+        }}
       />
       {canDelete && (
         <DeleteDialog


### PR DESCRIPTION
Fix #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * メンバー承認・却下後、対象ユーザー行が確実に一覧から即時削除されるようになりました。
  * 却下処理完了時の通知表示とダイアログの自動クローズ挙動を安定化しました。
  * フォーム送信時の処理を強化し、承認／却下の反映と画面挙動の一貫性を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniPro-tech/UniQUE/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->