### PR TITLE
Archive / Suspend時にセッションを消去する

### DIFF
--- a/UniQUE-API/src/internal/routes/users.go
+++ b/UniQUE-API/src/internal/routes/users.go
@@ -677,6 +677,14 @@ func updateUser(c *gin.Context) {
 			}
 		}
 
+		// statusが変更された場合
+		// もしstatusがsuspend / archiveならsessionまるまる消す
+		if updatesUser.Status == "suspended" || updatesUser.Status == "archived" {
+			if _, err := q.Session.Where(query.Session.UserID.Eq(id)).Delete(); err != nil {
+				return err
+			}
+		}
+
 		// Profileの処理
 		if input.Profile != nil {
 			existing, err := q.Profile.Where(query.Profile.UserID.Eq(user.ID)).First()

--- a/UniQUE-API/src/internal/routes/users.go
+++ b/UniQUE-API/src/internal/routes/users.go
@@ -927,6 +927,11 @@ func patchUser(c *gin.Context) {
 					return err
 				}
 			}
+			if *body.Status.Value == "suspended" || *body.Status.Value == "archived" {
+				if _, err := tx.Session.Where(tx.Session.UserID.Eq(id)).Delete(); err != nil {
+					return err
+				}
+			}
 		}
 
 		// プロフィールの更新


### PR DESCRIPTION
Fix #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ユーザーアカウントがサスペンド（停止）またはアーカイブ状態に変更された際に、既存のセッションが自動的に無効化されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniPro-tech/UniQUE/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->