### PR TITLE
申請時に連携するとDiscordサーバーに追加されない問題を修正

### DIFF
--- a/UniQUE-API/src/internal/routes/users.go
+++ b/UniQUE-API/src/internal/routes/users.go
@@ -1661,6 +1661,12 @@ func linkDiscordByEmailCode(c *gin.Context) {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
+
+	config := c.MustGet("config").(config.Config)
+	if err := discordutil.AddToGuild(input.ExternalUserID, db, &config); err != nil {
+		log.Printf("failed to add user to discord guild via email verify: %v", err)
+	}
+
 	resp := ExternalIdentityDTO{
 		ID:             ei.ID,
 		UserID:         ei.UserID,


### PR DESCRIPTION
Fixes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メールコード経由でDiscordアカウントをリンクする際、ユーザーが自動的にDiscordギルドに追加されるようになりました。ギルド追加に失敗した場合でもアカウントリンク処理は正常に完了します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->