### PR TITLE
設定ページのUI/UXに関するリファクタリング

### DIFF
--- a/UniQUE-Front/src/app/dashboard/settings/page.tsx
+++ b/UniQUE-Front/src/app/dashboard/settings/page.tsx
@@ -5,6 +5,7 @@ import AccountSettingsCard from "@/components/Pages/Settings/Cards/Account";
 import ConsentSettingsCard from "@/components/Pages/Settings/Cards/Consent";
 import SecuritySettingsCard from "@/components/Pages/Settings/Cards/Security";
 import SocialAccountsSettingsCard from "@/components/Pages/Settings/Cards/SocialAccounts";
+import SettingsTabs from "@/components/Pages/Settings/SettingsTabs";
 import TemporarySnackProvider, {
   type SnackbarData,
 } from "@/components/TemporarySnackProvider";
@@ -57,12 +58,14 @@ export default async function Page({
         </Typography>
       </Stack>
       {user && (
-        <>
+        <SettingsTabs
+          labels={["プロフィール", "セキュリティ", "外部連携", "アプリ権限"]}
+        >
           <AccountSettingsCard user={user} />
           <SecuritySettingsCard user={user} />
           <SocialAccountsSettingsCard user={user} />
           <ConsentSettingsCard user={user} />
-        </>
+        </SettingsTabs>
       )}
     </Stack>
   );

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Account/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Account/Client.tsx
@@ -101,7 +101,10 @@ export default function AccountSettingsCardClient({
                   カスタムIDを変更するには申請が必要です。
                   <Link
                     href="#"
-                    onClick={() => setOpenUserIdChangeDialog(true)}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setOpenUserIdChangeDialog(true);
+                    }}
                   >
                     申請する
                   </Link>

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Account/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Account/Client.tsx
@@ -2,7 +2,6 @@
 import { ErrorOutlineOutlined } from "@mui/icons-material";
 import VerifiedIcon from "@mui/icons-material/Verified";
 import {
-  Box,
   Button,
   Divider,
   FormHelperText,
@@ -64,21 +63,27 @@ export default function AccountSettingsCardClient({
   return (
     <Base sid={user.id} action={action} isPending={isPending}>
       <Stack spacing={2}>
-        <Box>
+        <Stack spacing={1}>
           <Typography variant="h5" component={"h3"}>
             基本設定
           </Typography>
           <Typography variant="body2">
             カスタムID、メールアドレスなどの変更を行います。
           </Typography>
-        </Box>
+        </Stack>
 
         {/* システム情報（変更不可） */}
-        <Box sx={{ p: 2, bgcolor: "background.paper", borderRadius: 1 }}>
-          <Typography variant={"subtitle1"} sx={{ mb: 2 }}>
-            システム情報
-          </Typography>
-          <Stack spacing={1}>
+        <Stack
+          spacing={2}
+          sx={{ p: 0, bgcolor: "background.paper", borderRadius: 1 }}
+        >
+          <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+            <Typography variant="h6" component={"h4"}>
+              システム情報
+            </Typography>
+            <Divider sx={{ flexGrow: 1 }} />
+          </Stack>
+          <Stack spacing={2}>
             <TextField
               required
               label="UUID"
@@ -91,13 +96,18 @@ export default function AccountSettingsCardClient({
               label="カスタムID"
               defaultValue={lastResult.user.customId}
               disabled
+              helperText={
+                <>
+                  カスタムIDを変更するには申請が必要です。
+                  <Link
+                    href="#"
+                    onClick={() => setOpenUserIdChangeDialog(true)}
+                  >
+                    申請する
+                  </Link>
+                </>
+              }
             />
-            <FormHelperText>
-              カスタムIDを変更するには申請が必要です。
-              <Link href="#" onClick={() => setOpenUserIdChangeDialog(true)}>
-                申請する
-              </Link>
-            </FormHelperText>
             <TextField
               required
               label="メールアドレス"
@@ -115,15 +125,21 @@ export default function AccountSettingsCardClient({
               disabled
             />
           </Stack>
-        </Box>
+        </Stack>
 
         <Divider />
 
         {/* ユーザー編集可能情報 */}
-        <Box sx={{ p: 2 }}>
-          <Typography variant={"subtitle1"} sx={{ mb: 2 }}>
-            編集可能情報
-          </Typography>
+        <Stack
+          spacing={2}
+          sx={{ p: 0, bgcolor: "background.paper", borderRadius: 1 }}
+        >
+          <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+            <Typography variant="h6" component={"h4"}>
+              編集可能情報
+            </Typography>
+            <Divider sx={{ flexGrow: 1 }} />
+          </Stack>
           <Stack spacing={2}>
             <TextField
               required
@@ -193,7 +209,7 @@ export default function AccountSettingsCardClient({
               <FormHelperText>一度設定したら変更できません。</FormHelperText>
             </Stack>
           </Stack>
-        </Box>
+        </Stack>
       </Stack>
       <Button variant="contained" fullWidth type="submit">
         保存

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Account/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Account/Client.tsx
@@ -2,9 +2,11 @@
 import { ErrorOutlineOutlined } from "@mui/icons-material";
 import VerifiedIcon from "@mui/icons-material/Verified";
 import {
+  Box,
   Button,
-  Chip,
+  Divider,
   FormHelperText,
+  InputAdornment,
   Link,
   Stack,
   TextField,
@@ -61,114 +63,138 @@ export default function AccountSettingsCardClient({
   };
   return (
     <Base sid={user.id} action={action} isPending={isPending}>
-      <Stack>
-        <Typography variant="h5" component={"h3"}>
-          基本設定
-        </Typography>
-        <Typography variant="body2">
-          カスタムID、メールアドレスなどの変更を行います。
-        </Typography>
-      </Stack>
-      <TextField
-        required
-        label="UUID"
-        defaultValue={lastResult.user.id}
-        disabled
-      />
-      <input type="hidden" name="id" value={lastResult.user.id} />
-      <TextField
-        required
-        label="表示名"
-        defaultValue={lastResult.user.profile?.displayName || ""}
-        name="display_name"
-      />
-      <Stack>
-        <TextField
-          required
-          label="カスタムID"
-          defaultValue={lastResult.user.customId}
-          disabled
-        />
-        <FormHelperText>
-          カスタムIDを変更するには申請が必要です。
-          <Link href="#" onClick={() => setOpenUserIdChangeDialog(true)}>
-            申請する
-          </Link>
-        </FormHelperText>
-      </Stack>
-      <Stack>
-        <TextField
-          required
-          label="メールアドレス"
-          defaultValue={lastResult.user.email}
-          disabled
-        />
-        <FormHelperText>
-          メールアドレスは原則として所属期とカスタムIDに基づいて自動生成されます。
-        </FormHelperText>
-      </Stack>
-      <Stack spacing={1}>
-        <TextField
-          required
-          label="外部メールアドレス"
-          defaultValue={
-            lastResult.user.pendingEmail || lastResult.user.externalEmail || ""
-          }
-          name="external_email"
-        />
-        {(lastResult.user.externalEmail || lastResult.user.pendingEmail) &&
-          (lastResult.user.emailVerified && !lastResult.user.pendingEmail ? (
-            <Chip
-              icon={<VerifiedIcon />}
-              label="認証済み"
-              color="success"
-              size="small"
-              sx={{ alignSelf: "flex-start" }}
+      <Stack spacing={2}>
+        <Box>
+          <Typography variant="h5" component={"h3"}>
+            基本設定
+          </Typography>
+          <Typography variant="body2">
+            カスタムID、メールアドレスなどの変更を行います。
+          </Typography>
+        </Box>
+
+        {/* システム情報（変更不可） */}
+        <Box sx={{ p: 2, bgcolor: "background.paper", borderRadius: 1 }}>
+          <Typography variant={"subtitle1"} sx={{ mb: 2 }}>
+            システム情報
+          </Typography>
+          <Stack spacing={1}>
+            <TextField
+              required
+              label="UUID"
+              defaultValue={lastResult.user.id}
+              disabled
             />
-          ) : (
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{
-                alignItems: "center",
+            <input type="hidden" name="id" value={lastResult.user.id} />
+            <TextField
+              required
+              label="カスタムID"
+              defaultValue={lastResult.user.customId}
+              disabled
+            />
+            <FormHelperText>
+              カスタムIDを変更するには申請が必要です。
+              <Link href="#" onClick={() => setOpenUserIdChangeDialog(true)}>
+                申請する
+              </Link>
+            </FormHelperText>
+            <TextField
+              required
+              label="メールアドレス"
+              defaultValue={lastResult.user.email}
+              disabled
+            />
+            <FormHelperText>
+              メールアドレスは原則として所属期とカスタムIDに基づいて自動生成されます。
+            </FormHelperText>
+            <TextField
+              label="所属期"
+              defaultValue={(
+                lastResult.user.affiliationPeriod || ""
+              ).toUpperCase()}
+              disabled
+            />
+          </Stack>
+        </Box>
+
+        <Divider />
+
+        {/* ユーザー編集可能情報 */}
+        <Box sx={{ p: 2 }}>
+          <Typography variant={"subtitle1"} sx={{ mb: 2 }}>
+            編集可能情報
+          </Typography>
+          <Stack spacing={2}>
+            <TextField
+              required
+              label="表示名"
+              defaultValue={lastResult.user.profile?.displayName || ""}
+              name="display_name"
+            />
+
+            <TextField
+              required
+              label="外部メールアドレス"
+              defaultValue={
+                lastResult.user.pendingEmail ||
+                lastResult.user.externalEmail ||
+                ""
+              }
+              name="external_email"
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {lastResult.user.externalEmail ||
+                      lastResult.user.pendingEmail ? (
+                        lastResult.user.emailVerified &&
+                        !lastResult.user.pendingEmail ? (
+                          <VerifiedIcon sx={{ color: "success.main" }} />
+                        ) : (
+                          <Stack
+                            direction="row"
+                            spacing={1}
+                            sx={{ alignItems: "center" }}
+                          >
+                            <ErrorOutlineOutlined
+                              sx={{ color: "warning.main" }}
+                            />
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              onClick={handleResendVerification}
+                              disabled={isSendingVerification}
+                            >
+                              {isSendingVerification
+                                ? "送信中..."
+                                : "認証メールを送信"}
+                            </Button>
+                          </Stack>
+                        )
+                      ) : null}
+                    </InputAdornment>
+                  ),
+                },
               }}
-            >
-              <Chip
-                icon={<ErrorOutlineOutlined />}
-                label="未認証"
-                color="warning"
-                size="small"
+            />
+
+            <Stack>
+              <TextField
+                required
+                label="生年月日"
+                type="date"
+                name="birthdate"
+                defaultValue={lastResult.user.profile?.birthdate || ""}
+                slotProps={{
+                  inputLabel: { shrink: true },
+                }}
+                disabled={!!lastResult.user.profile?.birthdate}
               />
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={handleResendVerification}
-                disabled={isSendingVerification}
-              >
-                {isSendingVerification ? "送信中..." : "認証メールを送信"}
-              </Button>
+              <FormHelperText>一度設定したら変更できません。</FormHelperText>
             </Stack>
-          ))}
+          </Stack>
+        </Box>
       </Stack>
-      <Stack>
-        <TextField
-          required
-          label="生年月日"
-          type="date"
-          name="birthdate"
-          defaultValue={lastResult.user.profile?.birthdate || ""}
-          slotProps={{
-            inputLabel: { shrink: true },
-          }}
-          disabled={!!lastResult.user.profile?.birthdate}
-        />
-        <FormHelperText>一度設定したら変更できません。</FormHelperText>
-      </Stack>
-      <TextField
-        label="所属期"
-        defaultValue={(lastResult.user.affiliationPeriod || "").toUpperCase()}
-        disabled
-      />
       <Button variant="contained" fullWidth type="submit">
         保存
       </Button>

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/Client.tsx
@@ -243,11 +243,12 @@ export default function ConsentSettingsCardClient({
 
                     {/* アクションと日付 */}
                     <Stack
-                      direction="row"
+                      direction={{ xs: "column", sm: "row" }}
                       sx={{
                         pt: 1,
                         justifyContent: "space-between",
-                        alignItems: "center",
+                        alignItems: { xs: "flex-start", sm: "center" },
+                        gap: 1,
                       }}
                     >
                       <Typography variant="caption" color="text.secondary">

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/Client.tsx
@@ -91,7 +91,7 @@ export default function ConsentSettingsCardClient({
     >
       {/* ヘッダー部分 */}
       <Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
-        <Typography variant="h6" sx={{ component: "h3" }}>
+        <Typography variant="h6" component="h3">
           アプリ連携（OAuth同意）
         </Typography>
         <Divider sx={{ flexGrow: 1, ml: 1 }} />

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/Client.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import AppsIcon from "@mui/icons-material/Apps";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   Card,
   Chip,
-  List,
-  ListItem,
+  Divider,
+  Link,
   Stack,
   Typography,
 } from "@mui/material";
@@ -50,8 +56,6 @@ export default function ConsentSettingsCardClient({
   const [consents, setConsents] = React.useState(initialConsents);
   const [revoking, setRevoking] = React.useState<string | null>(null);
 
-  // アプリ名の解決はサーバーサイドで行われる想定なので、ここでは何もしない
-
   const handleRevoke = async (consent: ConsentDTO) => {
     setRevoking(consent.id);
     try {
@@ -78,23 +82,40 @@ export default function ConsentSettingsCardClient({
   return (
     <Card
       variant="outlined"
-      sx={{ display: "flex", p: 2, flexDirection: "column", gap: 2 }}
+      sx={{
+        p: 3,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2.5,
+      }}
     >
-      <Stack>
-        <Typography variant="h5" component="h3">
+      {/* ヘッダー部分 */}
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
+        <Typography variant="h6" sx={{ component: "h3" }}>
           アプリ連携（OAuth同意）
         </Typography>
-        <Typography variant="body2">
-          アクセスを許可したアプリケーションの一覧です。取り消すと、そのアプリからのアクセスが無効になります。
-        </Typography>
+        <Divider sx={{ flexGrow: 1, ml: 1 }} />
       </Stack>
 
+      <Typography variant="body2" color="text.secondary" sx={{ mt: -0.5 }}>
+        アクセスを許可したアプリケーションの一覧です。取り消すと、そのアプリからのアクセスが無効になります。
+      </Typography>
+
       {consents.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          現在、同意しているアプリケーションはありません。
-        </Typography>
+        <Box
+          sx={{
+            p: 3,
+            bgcolor: "action.hover",
+            borderRadius: 2,
+            textAlign: "center",
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            現在、連携しているアプリケーションはありません。
+          </Typography>
+        </Box>
       ) : (
-        <List sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <Box>
           {consents.map((consent) => {
             const appLabel =
               consent.applicationName ||
@@ -104,106 +125,155 @@ export default function ConsentSettingsCardClient({
             const scopes = consent.scope
               ? consent.scope.split(" ").filter(Boolean)
               : [];
+
             return (
-              <ListItem key={consent.id} disablePadding>
-                <Card
+              <Accordion
+                key={consent.id}
+                disableGutters
+                elevation={0}
+                sx={{
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1.5,
+                  overflow: "hidden",
+                  "&:before": { display: "none" }, // デフォルトの怪しい線を消去
+                  "&:not(:last-child)": { mb: 1.5 }, // アプリ同士の適度な隙間
+                }}
+              >
+                <AccordionSummary
+                  expandIcon={<ExpandMoreIcon />}
                   sx={{
-                    p: 2,
-                    width: "100%",
-                    display: "flex",
-                    flexDirection: "row",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: 2,
+                    "&:hover": { bgcolor: "action.hover" },
+                    px: { xs: 2, sm: 3 },
                   }}
                 >
-                  <Box
-                    sx={{
-                      flex: 1,
-                      minWidth: 0,
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 1,
-                    }}
-                  >
-                    <Typography variant="subtitle1" noWrap>
+                  <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+                    <Typography
+                      variant="subtitle2"
+                      sx={{ fontWeight: "bold" }}
+                      noWrap
+                    >
                       {appLabel}
                     </Typography>
-                    {consent.applicationDescription && (
-                      <Typography variant="body2" color="text.secondary" noWrap>
-                        {consent.applicationDescription}
-                      </Typography>
-                    )}
-                    {consent.applicationWebsiteUrl && (
-                      <Typography variant="body2" color="text.secondary" noWrap>
-                        ウェブサイト:{" "}
-                        <a
-                          href={consent.applicationWebsiteUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {consent.applicationWebsiteUrl}
-                        </a>
-                      </Typography>
-                    )}
-                    {consent.applicationTermsUrl && (
-                      <Typography variant="body2" color="text.secondary" noWrap>
-                        利用規約:{" "}
-                        <a
-                          href={consent.applicationTermsUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {consent.applicationTermsUrl}
-                        </a>
-                      </Typography>
-                    )}
-                    {consent.applicationPrivacyPolicyUrl && (
-                      <Typography variant="body2" color="text.secondary" noWrap>
-                        プライバシーポリシー:{" "}
-                        <a
-                          href={consent.applicationPrivacyPolicyUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {consent.applicationPrivacyPolicyUrl}
-                        </a>
-                      </Typography>
-                    )}
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {consent.applicationDescription ||
+                        "クリックして詳細を表示"}
+                    </Typography>
+                  </Stack>
+                </AccordionSummary>
+
+                <AccordionDetails sx={{ pt: 0, pb: 2, px: { xs: 2, sm: 3 } }}>
+                  <Stack spacing={2}>
+                    <Divider />
+
+                    {/* リンク群 */}
+                    <Stack spacing={1}>
+                      {[
+                        {
+                          label: "ウェブサイト",
+                          url: consent.applicationWebsiteUrl,
+                        },
+                        { label: "利用規約", url: consent.applicationTermsUrl },
+                        {
+                          label: "プライバシーポリシー",
+                          url: consent.applicationPrivacyPolicyUrl,
+                        },
+                      ].map((link) =>
+                        link.url ? (
+                          <Typography
+                            key={link.label}
+                            variant="body2"
+                            sx={{
+                              display: "flex",
+                              alignItems: { xs: "flex-start", sm: "center" },
+                              gap: 1,
+                              flexDirection: { xs: "column", sm: "row" },
+                            }}
+                          >
+                            <Typography
+                              component="span"
+                              variant="body2"
+                              color="text.secondary"
+                              sx={{ minWidth: 145 }}
+                            >
+                              {link.label}:
+                            </Typography>
+                            <Link
+                              href={link.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              underline="hover"
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 0.5,
+                              }}
+                            >
+                              リンクを開く{" "}
+                              <OpenInNewIcon sx={{ fontSize: 16 }} />
+                            </Link>
+                          </Typography>
+                        ) : null,
+                      )}
+                    </Stack>
+
+                    {/* スコープ群 */}
                     {scopes.length > 0 && (
-                      <Stack
-                        direction="row"
-                        spacing={0.5}
-                        sx={{
-                          flexWrap: "wrap",
-                        }}
-                      >
-                        {scopes.map((s) => (
-                          <Chip key={s} label={s} size="small" />
-                        ))}
+                      <Stack spacing={1}>
+                        <Typography variant="caption" color="text.secondary">
+                          許可された権限:
+                        </Typography>
+                        <Stack
+                          direction="row"
+                          spacing={0.5}
+                          useFlexGap
+                          sx={{ flexWrap: "wrap" }}
+                        >
+                          {scopes.map((s) => (
+                            <Chip
+                              key={s}
+                              label={s}
+                              size="small"
+                              variant="outlined"
+                            />
+                          ))}
+                        </Stack>
                       </Stack>
                     )}
-                    {consent.createdAt && (
+
+                    {/* アクションと日付 */}
+                    <Stack
+                      direction="row"
+                      sx={{
+                        pt: 1,
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                      }}
+                    >
                       <Typography variant="caption" color="text.secondary">
-                        許可日:{" "}
-                        {new Date(consent.createdAt).toLocaleDateString()}
+                        {consent.createdAt
+                          ? `許可日: ${new Date(consent.createdAt).toLocaleDateString()}`
+                          : ""}
                       </Typography>
-                    )}
-                  </Box>
-                  <Button
-                    variant="outlined"
-                    color="error"
-                    size="small"
-                    disabled={revoking === consent.id}
-                    onClick={() => handleRevoke(consent)}
-                  >
-                    {revoking === consent.id ? "取り消し中..." : "取り消す"}
-                  </Button>
-                </Card>
-              </ListItem>
+                      <Button
+                        variant="outlined"
+                        color="error"
+                        size="small"
+                        disabled={revoking === consent.id}
+                        onClick={() => handleRevoke(consent)}
+                        disableElevation
+                      >
+                        {revoking === consent.id
+                          ? "取り消し中..."
+                          : "連携を取り消す"}
+                      </Button>
+                    </Stack>
+                  </Stack>
+                </AccordionDetails>
+              </Accordion>
             );
           })}
-        </List>
+        </Box>
       )}
     </Card>
   );

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/index.tsx
@@ -61,10 +61,38 @@ export default async function ConsentSettingsCard({
       return { ...c, applicationName: appId };
     }),
   );
+  const testConsents: ConsentDTO[] = [
+    {
+      id: "consent1",
+      clientId: "client1",
+      applicationId: "app1",
+      userId: user.id,
+      scope: "read write",
+      createdAt: new Date().toISOString(),
+      applicationName: "Test App 1",
+      applicationDescription: "This is a test application.",
+      applicationWebsiteUrl: "https://example.com",
+      applicationPrivacyPolicyUrl: "https://example.com/privacy",
+      applicationTermsUrl: "https://example.com/terms",
+    },
+    {
+      id: "consent1",
+      clientId: "client1",
+      applicationId: "app1",
+      userId: user.id,
+      scope: "read write",
+      createdAt: new Date().toISOString(),
+      applicationName: "Test App 1",
+      applicationDescription: "This is a test application.",
+      applicationWebsiteUrl: "https://example.com",
+      applicationPrivacyPolicyUrl: "https://example.com/privacy",
+      applicationTermsUrl: "https://example.com/terms",
+    },
+  ];
 
   return (
     <ConsentSettingsCardClient
-      consents={resolvedConsents}
+      consents={testConsents}
       revokeConsent={revokeConsentAction}
     />
   );

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Consent/index.tsx
@@ -61,38 +61,10 @@ export default async function ConsentSettingsCard({
       return { ...c, applicationName: appId };
     }),
   );
-  const testConsents: ConsentDTO[] = [
-    {
-      id: "consent1",
-      clientId: "client1",
-      applicationId: "app1",
-      userId: user.id,
-      scope: "read write",
-      createdAt: new Date().toISOString(),
-      applicationName: "Test App 1",
-      applicationDescription: "This is a test application.",
-      applicationWebsiteUrl: "https://example.com",
-      applicationPrivacyPolicyUrl: "https://example.com/privacy",
-      applicationTermsUrl: "https://example.com/terms",
-    },
-    {
-      id: "consent1",
-      clientId: "client1",
-      applicationId: "app1",
-      userId: user.id,
-      scope: "read write",
-      createdAt: new Date().toISOString(),
-      applicationName: "Test App 1",
-      applicationDescription: "This is a test application.",
-      applicationWebsiteUrl: "https://example.com",
-      applicationPrivacyPolicyUrl: "https://example.com/privacy",
-      applicationTermsUrl: "https://example.com/terms",
-    },
-  ];
 
   return (
     <ConsentSettingsCardClient
-      consents={testConsents}
+      consents={resolvedConsents}
       revokeConsent={revokeConsentAction}
     />
   );

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Client.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Card, Stack, Typography } from "@mui/material";
+import { Card, Chip, Divider, Stack, Typography } from "@mui/material";
 import React from "react";
 import type { SessionData } from "@/classes/Session";
 import type { UserData } from "@/classes/types/User";
@@ -20,20 +20,47 @@ export default function SecuritySettingsCardClient({
   const [open, setOpen] = React.useState(false);
   const handleClickOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+
+  const totpStatus = user.isTotpEnabled ? "有効" : "無効";
+  const sessionCount = sessions.length;
+
   return (
     <>
       <Card
         variant="outlined"
         sx={{ display: "flex", p: 2, flexDirection: "column", gap: 2 }}
       >
-        <Stack>
-          <Typography variant="h5" component={"h3"}>
-            セキュリティ設定
-          </Typography>
-          <Typography variant="body2">
-            パスワードの変更や二段階認証の設定を行います。
-          </Typography>
+        <Stack spacing={2}>
+          <Stack>
+            <Typography variant="h5" component={"h3"}>
+              セキュリティ設定
+            </Typography>
+            <Typography variant="body2">
+              パスワード、二段階認証、セッション管理をまとめて確認できます。
+            </Typography>
+          </Stack>
+
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ alignItems: "center", flexWrap: "wrap" }}
+          >
+            <Chip
+              label={`TOTP: ${totpStatus}`}
+              color={user.isTotpEnabled ? "success" : "default"}
+              size="small"
+            />
+            <Chip
+              label={`ログイン中の端末: ${sessionCount}件`}
+              variant="outlined"
+              size="small"
+            />
+            <Chip label="パスワード保護中" variant="outlined" size="small" />
+          </Stack>
         </Stack>
+
+        <Divider />
+
         <PasswordSection user={user} handleClickOpen={handleClickOpen} />
         <TOTPSection user={user} />
         <SessionsSection

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Client.tsx
@@ -41,9 +41,12 @@ export default function SecuritySettingsCardClient({
           </Stack>
 
           <Stack
-            direction="row"
+            direction={{ xs: "column", sm: "row" }}
             spacing={1}
-            sx={{ alignItems: "center", flexWrap: "wrap" }}
+            sx={{
+              alignItems: { xs: "flex-start", sm: "center" },
+              flexWrap: "wrap",
+            }}
           >
             <Chip
               label={`TOTP: ${totpStatus}`}

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Password/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Password/index.tsx
@@ -2,7 +2,6 @@
 import {
   Button,
   Divider,
-  FormHelperText,
   Link,
   Stack,
   TextField,
@@ -96,6 +95,18 @@ export default function PasswordSection({
         fullWidth
         value={currentPassword}
         onChange={(e) => setCurrentPassword(e.target.value)}
+        helperText={
+          <>
+            パスワードを忘れた場合は、{" "}
+            <Link
+              onClick={handleClickOpen}
+              underline="hover"
+              style={{ cursor: "pointer" }}
+            >
+              こちら
+            </Link>
+          </>
+        }
       />
       <TextField
         label="新しいパスワード"
@@ -131,16 +142,6 @@ export default function PasswordSection({
             "上記で入力したパスワードをもう一度ご入力ください"
           }
         />
-        <FormHelperText>
-          パスワードを忘れた場合は、{" "}
-          <Link
-            onClick={handleClickOpen}
-            underline="hover"
-            style={{ cursor: "pointer" }}
-          >
-            こちら
-          </Link>
-        </FormHelperText>
       </Stack>
       <Button variant="contained" fullWidth type="submit">
         保存

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Sessions/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Sessions/index.tsx
@@ -135,11 +135,11 @@ export default function SessionsSection({
                     {/* 情報部分 */}
                     <Stack spacing={1} sx={{ flexGrow: 1 }}>
                       <Stack
-                        direction="row"
+                        direction={{ xs: "column", sm: "row" }}
                         spacing={1}
                         useFlexGap
                         sx={{
-                          alignItems: "center",
+                          alignItems: { xs: "flex-start", sm: "center" },
                           flexGap: 1,
                         }}
                       >
@@ -173,7 +173,7 @@ export default function SessionsSection({
 
                       {/* メタデータ群 */}
                       <Stack
-                        direction="row"
+                        direction={{ xs: "column", sm: "row" }}
                         spacing={2}
                         useFlexGap
                         sx={{
@@ -184,11 +184,20 @@ export default function SessionsSection({
                       >
                         {session.ipAddress && (
                           <Stack
-                            direction="row"
+                            direction={{ xs: "row" }}
                             spacing={0.5}
-                            sx={{ alignItems: "center" }}
+                            sx={{
+                              alignItems: { xs: "flex-start", sm: "center" },
+                            }}
                           >
-                            <PublicIcon fontSize="small" color="inherit" />
+                            <Stack
+                              direction="row"
+                              spacing={0.5}
+                              sx={{ alignItems: "center" }}
+                            >
+                              <PublicIcon fontSize="small" color="inherit" />
+                              <Typography variant="caption">IP:</Typography>
+                            </Stack>
                             <Typography variant="caption">
                               {session.ipAddress}
                             </Typography>
@@ -196,13 +205,26 @@ export default function SessionsSection({
                         )}
                         {session.lastLoginAt && (
                           <Stack
-                            direction="row"
+                            direction={{ xs: "column", sm: "row" }}
                             spacing={0.5}
-                            sx={{ alignItems: "center" }}
+                            sx={{
+                              alignItems: { xs: "flex-start", sm: "center" },
+                            }}
                           >
-                            <AccessTimeIcon fontSize="small" color="inherit" />
+                            <Stack
+                              direction="row"
+                              spacing={0.5}
+                              sx={{ alignItems: "center" }}
+                            >
+                              <AccessTimeIcon
+                                fontSize="small"
+                                color="inherit"
+                              />
+                              <Typography variant="caption">
+                                最終ログイン:
+                              </Typography>
+                            </Stack>
                             <Typography variant="caption">
-                              最終ログイン:{" "}
                               {new Date(session.lastLoginAt).toLocaleString()}
                             </Typography>
                           </Stack>

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Sessions/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Sessions/index.tsx
@@ -71,7 +71,7 @@ export default function SessionsSection({
           alignItems: "center",
         }}
       >
-        <Typography variant="h6" sx={{ component: "h4" }}>
+        <Typography variant="h6" component={"h4"}>
           セッション管理
         </Typography>
         <Divider sx={{ flexGrow: 1 }} />

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Sessions/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/Sessions/index.tsx
@@ -1,5 +1,11 @@
 "use client";
 import {
+  AccessTime as AccessTimeIcon,
+  Devices as DevicesIcon,
+  Logout as LogoutIcon,
+  Public as PublicIcon,
+} from "@mui/icons-material";
+import {
   Box,
   Button,
   Card,
@@ -28,6 +34,7 @@ export default function SessionsSection({
     sessions: sessions as SessionData[],
     status: null as null | FormStatus,
   });
+
   useEffect(() => {
     if (latestResult.status) {
       enqueueSnackbar(latestResult.status.message, {
@@ -55,7 +62,8 @@ export default function SessionsSection({
   const displayedSessions = latestResult.sessions.slice(0, 5);
 
   return (
-    <Stack spacing={2}>
+    <Stack spacing={3}>
+      {/* ヘッダー部分 */}
       <Stack
         direction="row"
         spacing={2}
@@ -63,11 +71,12 @@ export default function SessionsSection({
           alignItems: "center",
         }}
       >
-        <Typography variant="h6" component={"h4"}>
+        <Typography variant="h6" sx={{ component: "h4" }}>
           セッション管理
         </Typography>
         <Divider sx={{ flexGrow: 1 }} />
       </Stack>
+
       {latestResult.sessions.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           現在アクティブなセッションはありません。
@@ -78,81 +87,141 @@ export default function SessionsSection({
             display: "flex",
             flexDirection: "column",
             gap: 2,
+            p: 0,
           }}
         >
           {displayedSessions.map((session) => {
             const ua = session.userAgent ? parseUA(session.userAgent) : null;
             const isDeleted = session.deletedAt !== null;
+            const isActive = session.id === activeSessionId && !isDeleted;
+
             return (
               <ListItem key={session.id} disablePadding>
                 <Card
+                  variant="outlined"
                   sx={{
-                    p: 2,
+                    p: 2.5,
                     width: "100%",
                     display: "flex",
-                    flexDirection: "row",
-                    alignItems: "center",
+                    flexDirection: { xs: "column", sm: "row" },
+                    alignItems: { xs: "flex-start", sm: "center" },
                     justifyContent: "space-between",
                     gap: 2,
                     opacity: isDeleted ? 0.6 : 1,
+                    transition: "box-shadow 0.2s",
+                    "&:hover": {
+                      boxShadow: isDeleted ? "none" : 1,
+                    },
                   }}
                 >
-                  <Box>
-                    <Stack
-                      direction="row"
-                      spacing={1}
+                  <Stack
+                    direction="row"
+                    spacing={2}
+                    sx={{ flexGrow: 1, alignItems: "flex-start" }}
+                  >
+                    {/* アイコン部分 */}
+                    <Box
                       sx={{
-                        alignItems: "center",
+                        p: 1.5,
+                        borderRadius: 2,
+                        bgcolor: isActive ? "primary.50" : "action.hover",
+                        color: isActive ? "primary.main" : "text.secondary",
+                        display: "flex",
                       }}
                     >
-                      <Typography variant="body1">
-                        {ua
-                          ? ua.browser !== "Unknown" || ua.os !== "Unknown"
-                            ? `${ua.browser} - ${ua.os}`
-                            : session.userAgent
-                          : `セッション ${session.id.slice(0, 8)}`}
-                      </Typography>
-                      {session.id === activeSessionId && !isDeleted && (
-                        <Chip
-                          label="現在のセッション"
-                          color="primary"
-                          size="small"
-                          variant="outlined"
-                          sx={{ ml: 1 }}
-                        />
-                      )}
-                      {isDeleted && (
-                        <Chip
-                          label="削除済み"
-                          color="error"
-                          size="small"
-                          variant="outlined"
-                          sx={{ ml: 1 }}
-                        />
-                      )}
+                      <DevicesIcon />
+                    </Box>
+
+                    {/* 情報部分 */}
+                    <Stack spacing={1} sx={{ flexGrow: 1 }}>
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        useFlexGap
+                        sx={{
+                          alignItems: "center",
+                          flexGap: 1,
+                        }}
+                      >
+                        <Typography
+                          variant="subtitle1"
+                          sx={{ fontWeight: "bold", lineHeight: 1.2 }}
+                        >
+                          {ua
+                            ? ua.browser !== "Unknown" || ua.os !== "Unknown"
+                              ? `${ua.browser} - ${ua.os}`
+                              : session.userAgent
+                            : `セッション ${session.id.slice(0, 8)}`}
+                        </Typography>
+
+                        {isActive && (
+                          <Chip
+                            label="現在のセッション"
+                            color="primary"
+                            size="small"
+                          />
+                        )}
+                        {isDeleted && (
+                          <Chip
+                            label="削除済み"
+                            color="error"
+                            size="small"
+                            variant="outlined"
+                          />
+                        )}
+                      </Stack>
+
+                      {/* メタデータ群 */}
+                      <Stack
+                        direction="row"
+                        spacing={2}
+                        useFlexGap
+                        sx={{
+                          color: "text.secondary",
+                          mt: 0.5,
+                          flexWrap: "wrap",
+                        }}
+                      >
+                        {session.ipAddress && (
+                          <Stack
+                            direction="row"
+                            spacing={0.5}
+                            sx={{ alignItems: "center" }}
+                          >
+                            <PublicIcon fontSize="small" color="inherit" />
+                            <Typography variant="caption">
+                              {session.ipAddress}
+                            </Typography>
+                          </Stack>
+                        )}
+                        {session.lastLoginAt && (
+                          <Stack
+                            direction="row"
+                            spacing={0.5}
+                            sx={{ alignItems: "center" }}
+                          >
+                            <AccessTimeIcon fontSize="small" color="inherit" />
+                            <Typography variant="caption">
+                              最終ログイン:{" "}
+                              {new Date(session.lastLoginAt).toLocaleString()}
+                            </Typography>
+                          </Stack>
+                        )}
+                      </Stack>
                     </Stack>
-                    {session.ipAddress && (
-                      <Typography variant="body2" color="text.secondary">
-                        IPアドレス: {session.ipAddress}
-                      </Typography>
-                    )}
-                    {session.lastLoginAt && (
-                      <Typography variant="body2" color="text.secondary">
-                        最終ログイン:{" "}
-                        {new Date(session.lastLoginAt).toLocaleString()}
-                      </Typography>
-                    )}
-                    <Typography variant="body2" color="text.secondary">
-                      作成日: {new Date(session.createdAt).toLocaleString()}
-                    </Typography>
-                    {session.expiresAt && (
-                      <Typography variant="body2" color="text.secondary">
-                        有効期限: {new Date(session.expiresAt).toLocaleString()}
-                      </Typography>
-                    )}
-                  </Box>
+                  </Stack>
+
+                  {/* アクション部分 */}
                   {!isDeleted && (
-                    <Box component="form" action={action}>
+                    <Box
+                      component="form"
+                      action={action}
+                      sx={{
+                        width: { xs: "100%", sm: "auto" },
+                        display: "flex",
+                        justifyContent: "flex-end",
+                      }}
+                    >
                       <input
                         type="hidden"
                         name="sessionId"
@@ -163,8 +232,10 @@ export default function SessionsSection({
                         variant="outlined"
                         size="small"
                         color="error"
+                        startIcon={<LogoutIcon />}
                         disabled={session.id === activeSessionId}
                         sx={{
+                          whiteSpace: "nowrap",
                           cursor:
                             session.id === activeSessionId
                               ? "not-allowed"

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/TOTP/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/TOTP/index.tsx
@@ -109,7 +109,7 @@ export default function TOTPSection({ user }: { user: UserData }) {
     <Stack spacing={3}>
       {/* ヘッダー部分 */}
       <Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
-        <Typography variant="h6" sx={{ component: "h4" }}>
+        <Typography variant="h6" component={"h4"}>
           二段階認証（TOTP）
         </Typography>
         <Divider sx={{ flexGrow: 1, ml: 2 }} />

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/TOTP/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/TOTP/index.tsx
@@ -1,10 +1,18 @@
 "use client";
 import {
+  GppBad as GppBadIcon,
+  GppGood as GppGoodIcon,
+  QrCode as QrCodeIcon,
+} from "@mui/icons-material";
+import {
   Box,
   Button,
+  Card,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
+  DialogContentText,
   DialogTitle,
   Divider,
   Stack,
@@ -71,6 +79,7 @@ export default function TOTPSection({ user }: { user: UserData }) {
       Promise.resolve().then(() => {
         setLocalEnabled(true);
         setIsFinished(false);
+        setCode("");
       });
     } else if (verifyResult && verifyResult.valid === false) {
       enqueueSnackbar("コードが無効です。再度ご確認ください。", {
@@ -97,142 +106,243 @@ export default function TOTPSection({ user }: { user: UserData }) {
   const uri = genResult?.uri || null;
 
   return (
-    <Stack spacing={2} sx={{ p: 2 }}>
-      <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
-        <Typography variant="h6" component={"h4"}>
+    <Stack spacing={3}>
+      {/* ヘッダー部分 */}
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
+        <Typography variant="h6" sx={{ component: "h4" }}>
           二段階認証（TOTP）
         </Typography>
-        <Divider sx={{ flexGrow: 1 }} />
+        <Divider sx={{ flexGrow: 1, ml: 2 }} />
       </Stack>
 
-      <Box>
-        <Typography variant="body2" color="text.secondary">
-          現在の状態: {localEnabled ? "有効" : "無効"}
-        </Typography>
-      </Box>
+      {/* ステータスとアクションボタン */}
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={3}
+        sx={{ alignItems: { xs: "flex-start", sm: "center" } }}
+      >
+        <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+          <Typography variant="body1" sx={{ fontWeight: "medium" }}>
+            現在の状態
+          </Typography>
+          {localEnabled ? (
+            <Chip
+              icon={<GppGoodIcon />}
+              label="有効"
+              color="success"
+              variant="filled"
+              size="small"
+              sx={{ fontWeight: "bold" }}
+            />
+          ) : (
+            <Chip
+              icon={<GppBadIcon />}
+              label="無効"
+              color="default"
+              variant="filled"
+              size="small"
+            />
+          )}
+        </Stack>
 
-      {!localEnabled && !genResult?.secret && (
-        <>
+        {!localEnabled && !genResult?.secret && (
           <Button
-            variant="outlined"
-            sx={{ alignSelf: "flex-start" }}
+            variant="contained"
+            color="primary"
             onClick={() => setOpenDialog(true)}
+            disableElevation
           >
             セットアップを開始
           </Button>
+        )}
 
-          <Dialog
-            open={openDialog}
-            onClose={() => setOpenDialog(false)}
-            fullWidth
-            maxWidth="xs"
-          >
-            <DialogTitle>二段階認証のセットアップ</DialogTitle>
-            <DialogContent>
-              <Box component="form" action={genAction} id="totp-gen-form">
-                <input type="hidden" name="user_id" value={user.id} />
-                <TextField
-                  autoFocus
-                  margin="dense"
-                  label="パスワード"
-                  name="password"
-                  type="password"
-                  fullWidth
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                />
-              </Box>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setOpenDialog(false)}>キャンセル</Button>
-              <Button type="submit" form="totp-gen-form" variant="contained">
-                確認して生成
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </>
-      )}
-
-      {localEnabled && (
-        <>
+        {localEnabled && (
           <Button
             variant="outlined"
             color="error"
-            sx={{ alignSelf: "flex-start" }}
             onClick={() => setOpenDisableDialog(true)}
           >
-            無効化
+            無効化する
           </Button>
+        )}
+      </Stack>
 
-          <Dialog
-            open={openDisableDialog}
-            onClose={() => setOpenDisableDialog(false)}
-            fullWidth
-            maxWidth="xs"
+      {/* セットアップ領域（QRコード表示部） */}
+      {genResult?.secret && isFinished && !localEnabled && (
+        <Card
+          variant="outlined"
+          sx={{ p: 3, bgcolor: "info.50", borderColor: "info.200" }}
+        >
+          <Stack
+            spacing={3}
+            direction={{ xs: "column", md: "row" }}
+            sx={{ alignItems: "center" }}
           >
-            <DialogTitle>二段階認証の無効化</DialogTitle>
-            <DialogContent>
+            {uri && (
               <Box
-                component="form"
-                action={disableAction}
-                id="totp-disable-form"
+                sx={{
+                  p: 2,
+                  bgcolor: "white",
+                  borderRadius: 2,
+                  boxShadow: 1,
+                  display: "flex",
+                }}
               >
-                <TextField
-                  autoFocus
-                  margin="dense"
-                  label="パスワード"
-                  name="password"
-                  type="password"
-                  fullWidth
-                  value={disablePassword}
-                  onChange={(e) => setDisablePassword(e.target.value)}
-                />
+                <QRCodeCanvas value={uri} size={160} />
               </Box>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setOpenDisableDialog(false)}>
-                キャンセル
-              </Button>
-              <Button
-                type="submit"
-                form="totp-disable-form"
-                variant="contained"
-              >
-                無効化する
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </>
+            )}
+
+            <Stack spacing={2} sx={{ flexGrow: 1, width: "100%" }}>
+              <Box>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ alignItems: "center", mb: 1 }}
+                >
+                  <QrCodeIcon color="info" fontSize="small" />
+                  <Typography
+                    variant="subtitle2"
+                    sx={{ fontWeight: "bold", color: "info.dark" }}
+                  >
+                    認証アプリでQRコードをスキャン
+                  </Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" gutterBottom>
+                  Google Authenticator
+                  などの認証アプリを使用してQRコードを読み取ってください。カメラが使えない場合は、以下のシークレットを手動で入力してください。
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    mt: 1,
+                    p: 1,
+                    bgcolor: "white",
+                    borderRadius: 1,
+                    fontFamily: "monospace",
+                    border: "1px solid",
+                    borderColor: "grey.300",
+                    wordBreak: "break-all",
+                  }}
+                >
+                  シークレット: <strong>{genResult.secret}</strong>
+                </Typography>
+              </Box>
+
+              <Box component="form" action={verifyAction} sx={{ mt: 1 }}>
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={2}
+                  sx={{ alignItems: "flex-start" }}
+                >
+                  <TextField
+                    label="6桁の認証コード"
+                    name="code"
+                    value={code}
+                    onChange={(e) => setCode(e.target.value)}
+                    size="small"
+                    fullWidth
+                    sx={{ bgcolor: "white", borderRadius: 1 }}
+                  />
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    color="primary"
+                    disabled={!code}
+                    sx={{ whiteSpace: "nowrap", py: 1 }}
+                    disableElevation
+                  >
+                    有効化
+                  </Button>
+                </Stack>
+              </Box>
+            </Stack>
+          </Stack>
+        </Card>
       )}
 
-      {genResult?.secret && isFinished && (
-        <Stack spacing={2}>
-          <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
-            {uri ? <QRCodeCanvas value={uri} size={200} /> : null}
-            <Box>
-              <Typography variant="body2">
-                シークレット: {genResult.secret}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                QR またはシークレットを認証アプリに登録してください。
-              </Typography>
-            </Box>
-          </Box>
-
-          <Box component="form" action={verifyAction}>
+      {/* セットアップ用パスワードダイアログ */}
+      <Dialog
+        open={openDialog}
+        onClose={() => setOpenDialog(false)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>二段階認証のセットアップ</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }} variant="body2">
+            セキュリティ上の理由から、続行するには現在のパスワードを入力してください。
+          </DialogContentText>
+          <Box component="form" action={genAction} id="totp-gen-form">
+            <input type="hidden" name="user_id" value={user.id} />
             <TextField
-              label="認証コード"
-              name="code"
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
+              autoFocus
+              margin="dense"
+              label="パスワード"
+              name="password"
+              type="password"
               fullWidth
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
-            <Button type="submit" variant="contained" sx={{ mt: 1 }}>
-              有効化
-            </Button>
           </Box>
-        </Stack>
-      )}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setOpenDialog(false)} color="inherit">
+            キャンセル
+          </Button>
+          <Button
+            type="submit"
+            form="totp-gen-form"
+            variant="contained"
+            disableElevation
+          >
+            確認して生成
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 無効化用パスワードダイアログ */}
+      <Dialog
+        open={openDisableDialog}
+        onClose={() => setOpenDisableDialog(false)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle sx={{ fontWeight: "bold", color: "error.main" }}>
+          二段階認証の無効化
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }} variant="body2">
+            アカウントのセキュリティレベルが低下します。続行するには現在のパスワードを入力してください。
+          </DialogContentText>
+          <Box component="form" action={disableAction} id="totp-disable-form">
+            <TextField
+              autoFocus
+              margin="dense"
+              label="パスワード"
+              name="password"
+              type="password"
+              fullWidth
+              value={disablePassword}
+              onChange={(e) => setDisablePassword(e.target.value)}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setOpenDisableDialog(false)} color="inherit">
+            キャンセル
+          </Button>
+          <Button
+            type="submit"
+            form="totp-disable-form"
+            variant="contained"
+            color="error"
+            disableElevation
+          >
+            無効化する
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Stack>
   );
 }

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/Security/TOTP/index.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/Security/TOTP/index.tsx
@@ -285,20 +285,29 @@ export default function TOTPSection({ user }: { user: UserData }) {
               onChange={(e) => setPassword(e.target.value)}
             />
           </Box>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={() => setOpenDialog(false)} color="inherit">
-            キャンセル
-          </Button>
-          <Button
-            type="submit"
-            form="totp-gen-form"
-            variant="contained"
-            disableElevation
+          <DialogActions
+            sx={{
+              flexDirection: { xs: "column", sm: "row" },
+            }}
           >
-            確認して生成
-          </Button>
-        </DialogActions>
+            <Button
+              onClick={() => setOpenDialog(false)}
+              color="inherit"
+              sx={{ width: { xs: "100%", sm: "auto" } }}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              form="totp-gen-form"
+              variant="contained"
+              disableElevation
+              sx={{ width: { xs: "100%", sm: "auto" } }}
+            >
+              確認して生成
+            </Button>
+          </DialogActions>
+        </DialogContent>
       </Dialog>
 
       {/* 無効化用パスワードダイアログ */}
@@ -327,21 +336,30 @@ export default function TOTPSection({ user }: { user: UserData }) {
               onChange={(e) => setDisablePassword(e.target.value)}
             />
           </Box>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={() => setOpenDisableDialog(false)} color="inherit">
-            キャンセル
-          </Button>
-          <Button
-            type="submit"
-            form="totp-disable-form"
-            variant="contained"
-            color="error"
-            disableElevation
+          <DialogActions
+            sx={{
+              flexDirection: { xs: "column", sm: "row" },
+            }}
           >
-            無効化する
-          </Button>
-        </DialogActions>
+            <Button
+              onClick={() => setOpenDisableDialog(false)}
+              color="inherit"
+              sx={{ width: { xs: "100%", sm: "auto" } }}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              form="totp-disable-form"
+              variant="contained"
+              color="error"
+              disableElevation
+              sx={{ width: { xs: "100%", sm: "auto" } }}
+            >
+              無効化する
+            </Button>
+          </DialogActions>
+        </DialogContent>
       </Dialog>
     </Stack>
   );

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/SocialAccounts/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/SocialAccounts/Client.tsx
@@ -10,6 +10,8 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  List,
+  ListItem,
   Stack,
   Typography,
 } from "@mui/material";
@@ -21,6 +23,7 @@ import { deleteAction } from "./action";
 
 /** Discord brand colour */
 const DISCORD_COLOR = "#5865F2";
+const DISCORD_HOVER_COLOR = "#4752C4";
 
 /** Resolve a readable name from the identity with fallbacks */
 function resolveDisplayName(identity: ExternalIdentityData): string {
@@ -59,147 +62,164 @@ function SocialAccountsContent({
     <Card
       variant="outlined"
       sx={{
+        p: 3,
         display: "flex",
-        p: 2,
-        pb: 5,
         flexDirection: "column",
-        gap: 2,
+        gap: 3,
       }}
     >
-      <Typography variant="h5" component={"h3"}>
-        ソーシャルアカウント設定
-      </Typography>
-      <Typography variant="body2">
-        ソーシャルアカウントの連携設定を行います。
-      </Typography>
-
-      <Stack
-        direction={"row"}
-        spacing={1}
-        sx={{
-          alignItems: "center",
-        }}
-      >
-        <Typography
-          variant="h6"
-          sx={{
-            textAlign: "left",
-          }}
-        >
-          Discordアカウント
+      <Stack spacing={0.5}>
+        <Typography variant="h6" sx={{ component: "h3" }}>
+          ソーシャルアカウント設定
         </Typography>
-        <Divider sx={{ flexGrow: 1 }} />
-        {hasDiscordIdentity && (
-          <Chip
-            label={`連携済み (${discordIdentities.length})`}
-            color="success"
-            size="small"
-          />
+        <Typography variant="body2" color="text.secondary">
+          外部サービスのアカウントを連携して、ログインに利用できます。
+        </Typography>
+      </Stack>
+
+      <Stack spacing={2}>
+        <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+          <Typography variant="subtitle1">Discord</Typography>
+          <Divider sx={{ flexGrow: 1 }} />
+          {hasDiscordIdentity && (
+            <Chip
+              label={`連携済み (${discordIdentities.length})`}
+              color="success"
+              size="small"
+              variant="outlined"
+            />
+          )}
+        </Stack>
+
+        {hasDiscordIdentity ? (
+          <List
+            sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 0 }}
+          >
+            {discordIdentities.map((identity) => (
+              <ListItem key={identity.id} disablePadding>
+                <Box
+                  sx={{
+                    width: "100%",
+                    display: "flex",
+                    alignItems: { xs: "flex-start", sm: "center" },
+                    flexDirection: { xs: "column", sm: "row" },
+                    justifyContent: "space-between",
+                    gap: 2,
+                    p: 2,
+                    borderRadius: 2,
+                    bgcolor: "action.hover",
+                  }}
+                >
+                  <Stack
+                    direction="row"
+                    spacing={2}
+                    sx={{
+                      alignItems: "center",
+                      minWidth: 0,
+                    }}
+                  >
+                    <Avatar
+                      src={identity.avatarUrl}
+                      alt={resolveDisplayName(identity)}
+                      sx={{
+                        width: 48,
+                        height: 48,
+                        bgcolor: DISCORD_COLOR,
+                        fontSize: "1.2rem",
+                        fontWeight: "bold",
+                      }}
+                    >
+                      {resolveDisplayName(identity).charAt(0).toUpperCase()}
+                    </Avatar>
+
+                    <Stack sx={{ minWidth: 0 }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: "bold" }}
+                        noWrap
+                      >
+                        {resolveDisplayName(identity)}
+                      </Typography>
+                      {identity.username && (
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          noWrap
+                        >
+                          @{identity.username}
+                        </Typography>
+                      )}
+                      {identity.email && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                        >
+                          {identity.email}
+                        </Typography>
+                      )}
+                    </Stack>
+                  </Stack>
+
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    size="small"
+                    onClick={() => handleUnlink(identity.id, "Discord")}
+                    disabled={isPending}
+                    sx={{ alignSelf: { xs: "flex-end", sm: "auto" } }}
+                  >
+                    連携を解除
+                  </Button>
+                </Box>
+              </ListItem>
+            ))}
+
+            <ListItem disablePadding sx={{ mt: 1 }}>
+              <Button
+                variant="outlined"
+                href={`/api/oauth/discord`}
+                disabled={isPending}
+                sx={{
+                  color: DISCORD_COLOR,
+                  borderColor: DISCORD_COLOR,
+                  "&:hover": {
+                    borderColor: DISCORD_HOVER_COLOR,
+                    bgcolor: "rgba(88, 101, 242, 0.04)",
+                  },
+                }}
+              >
+                別のアカウントを追加
+              </Button>
+            </ListItem>
+          </List>
+        ) : (
+          <Stack spacing={2} sx={{ alignItems: "flex-start" }}>
+            <Typography variant="body2" color="text.secondary">
+              Discordアカウントを連携すると、次回からパスワードなしでログインできます。
+            </Typography>
+            <Button
+              variant="contained"
+              href={`/api/oauth/discord`}
+              disabled={isPending}
+              sx={{
+                bgcolor: DISCORD_COLOR,
+                "&:hover": { bgcolor: DISCORD_HOVER_COLOR },
+              }}
+              disableElevation
+            >
+              Discordと連携する
+            </Button>
+          </Stack>
         )}
       </Stack>
 
-      {hasDiscordIdentity ? (
-        <Stack spacing={2}>
-          {discordIdentities.map((identity) => (
-            <Box
-              key={identity.id}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 2,
-                p: 1.5,
-                borderRadius: 2,
-                border: "1px solid",
-                borderColor: "divider",
-                bgcolor: "action.hover",
-                flexWrap: "wrap",
-              }}
-            >
-              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-                <Avatar
-                  src={identity.avatarUrl}
-                  alt={resolveDisplayName(identity)}
-                  sx={{
-                    width: 52,
-                    height: 52,
-                    bgcolor: DISCORD_COLOR,
-                    fontSize: "1.3rem",
-                  }}
-                >
-                  {/* Fallback: first letter */}
-                  {resolveDisplayName(identity).charAt(0).toUpperCase()}
-                </Avatar>
-
-                <Stack sx={{ minWidth: 0 }}>
-                  <Typography
-                    variant="subtitle1"
-                    noWrap
-                    sx={{
-                      fontWeight: 700,
-                    }}
-                  >
-                    {resolveDisplayName(identity)}
-                  </Typography>
-
-                  {identity.username && (
-                    <Typography variant="body2" color="text.secondary" noWrap>
-                      @{identity.username}
-                    </Typography>
-                  )}
-
-                  {identity.email && (
-                    <Typography variant="caption" color="text.secondary" noWrap>
-                      {identity.email}
-                    </Typography>
-                  )}
-                </Stack>
-              </Box>
-
-              <Button
-                variant="outlined"
-                color="error"
-                onClick={() => handleUnlink(identity.id, "Discord")}
-                disabled={isPending}
-                sx={{ maxWidth: 300 }}
-              >
-                連携を解除
-              </Button>
-            </Box>
-          ))}
-
-          <Button
-            variant="contained"
-            color="primary"
-            href={`/api/oauth/discord`}
-            disabled={isPending}
-            sx={{ maxWidth: 300 }}
-          >
-            Discordアカウントを追加する
-          </Button>
-        </Stack>
-      ) : (
-        <Stack spacing={1}>
-          <Typography variant="body2" color="text.secondary">
-            Discordアカウントを連携すると、Discord経由でログインができます。
-          </Typography>
-          <Button
-            variant="contained"
-            color="primary"
-            href={`/api/oauth/discord`}
-            disabled={isPending}
-            sx={{ maxWidth: 300 }}
-          >
-            Discordアカウントを連携する
-          </Button>
-        </Stack>
-      )}
       <UnlinkDialog
         userId={user.id}
-        identityId={unlinkingIdentityId} // This will be set when opening the dialog
-        provider={unlinkingProvider} // This will be set when opening the dialog
-        open={isUnlinkDialogOpen} // This will be controlled by state
-        onClose={() => setIsUnlinkDialogOpen(false)} // This will be implemented to handle dialog close
+        identityId={unlinkingIdentityId}
+        provider={unlinkingProvider}
+        open={isUnlinkDialogOpen}
+        onClose={() => setIsUnlinkDialogOpen(false)}
         startTransition={startTransition}
         setExternalIdentities={setExternalIdentities}
       />
@@ -262,19 +282,25 @@ function UnlinkDialog({
       }
     });
   };
+
   return (
-    <Dialog open={open} onClose={() => onClose(false)}>
-      <DialogTitle>{`${provider}アカウントの連携を解除しますか?`}</DialogTitle>
+    <Dialog open={open} onClose={() => onClose(false)} maxWidth="xs" fullWidth>
+      <DialogTitle>連携解除の確認</DialogTitle>
       <DialogContent>
         <Typography variant="body2">
-          {`${provider}アカウントの連携を解除してもよろしいですか?`}
+          本当に {provider} アカウントの連携を解除してもよろしいですか？
         </Typography>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={() => onClose(false)} color="primary">
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={() => onClose(false)} color="inherit">
           キャンセル
         </Button>
-        <Button onClick={handleUnlink} color="error" variant="contained">
+        <Button
+          onClick={handleUnlink}
+          color="error"
+          variant="contained"
+          disableElevation
+        >
           連携を解除
         </Button>
       </DialogActions>

--- a/UniQUE-Front/src/components/Pages/Settings/Cards/SocialAccounts/Client.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/Cards/SocialAccounts/Client.tsx
@@ -69,7 +69,7 @@ function SocialAccountsContent({
       }}
     >
       <Stack spacing={0.5}>
-        <Typography variant="h6" sx={{ component: "h3" }}>
+        <Typography variant="h6" component="h3">
           ソーシャルアカウント設定
         </Typography>
         <Typography variant="body2" color="text.secondary">

--- a/UniQUE-Front/src/components/Pages/Settings/SettingsTabs.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/SettingsTabs.tsx
@@ -37,6 +37,7 @@ export default function SettingsTabs({
         variant="scrollable"
         scrollButtons="auto"
         aria-label="settings tabs"
+        sx={{ mb: 2 }}
       >
         {labels.map((label, i) => (
           <Tab key={label} label={label} {...a11yProps(i)} />
@@ -51,7 +52,7 @@ export default function SettingsTabs({
           aria-labelledby={`settings-tab-${i}`}
           hidden={value !== i}
         >
-          {value === i && <Box sx={{ pt: 2 }}>{child}</Box>}
+          {value === i && <Box sx={{ pt: 2, pb: 2, px: 0 }}>{child}</Box>}
         </div>
       ))}
     </Box>

--- a/UniQUE-Front/src/components/Pages/Settings/SettingsTabs.tsx
+++ b/UniQUE-Front/src/components/Pages/Settings/SettingsTabs.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Box, Tab, Tabs } from "@mui/material";
+import React from "react";
+
+type Props = {
+  labels: string[];
+  children: React.ReactNode;
+  defaultIndex?: number;
+};
+
+function a11yProps(index: number) {
+  return {
+    id: `settings-tab-${index}`,
+    "aria-controls": `settings-tabpanel-${index}`,
+  };
+}
+
+export default function SettingsTabs({
+  labels,
+  children,
+  defaultIndex = 0,
+}: Props) {
+  const [value, setValue] = React.useState(defaultIndex);
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const childrenArray = React.Children.toArray(children);
+
+  return (
+    <Box>
+      <Tabs
+        value={value}
+        onChange={handleChange}
+        variant="scrollable"
+        scrollButtons="auto"
+        aria-label="settings tabs"
+      >
+        {labels.map((label, i) => (
+          <Tab key={label} label={label} {...a11yProps(i)} />
+        ))}
+      </Tabs>
+
+      {childrenArray.map((child, i) => (
+        <div
+          key={labels[i]}
+          role="tabpanel"
+          id={`settings-tabpanel-${i}`}
+          aria-labelledby={`settings-tab-${i}`}
+          hidden={value !== i}
+        >
+          {value === i && <Box sx={{ pt: 2 }}>{child}</Box>}
+        </div>
+      ))}
+    </Box>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 設定ページをタブ表示に変更（プロフィール、セキュリティ、外部連携、アプリ権限タブ）
  * アカウント設定をシステム情報と編集可能情報の2セクションに再構成
  * セキュリティ状態（TOTP有効/無効、ログイン中端末数、パスワード保護状態）をチップで可視化
  * 外部メールアドレスの認証状態表示を更新
  * セッション情報の表示項目を簡潔化（IPアドレスと最終ログイン時刻のみ表示）
  * 外部連携UIをリスト表示に変更

<!-- end of auto-generated comment: release notes by coderabbit.ai -->